### PR TITLE
vcs should also download foonathan repo because its a new fastRTPS dependency [#6122]

### DIFF
--- a/discovery-server.repos
+++ b/discovery-server.repos
@@ -15,3 +15,7 @@ repositories:
         type: git
         url: https://github.com/leethomason/tinyxml2.git
         version: master
+    foonathan_memory_vendor:
+        type: git
+        url: https://github.com/eProsima/foonathan_memory_vendor.git
+        version: master


### PR DESCRIPTION
update of discovery-server.repos, note that vcs doesn't admit any tabs within this file. New repo dependency:
```
    foonathan_memory_vendor:
        type: git
        url: https://github.com/eProsima/foonathan_memory_vendor.git
        version: master
```
