### PR TITLE
Refs #6153 Making openSSL not mandatory 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,23 @@ find_package(OpenSSL QUIET) # according to cmake docs on FindOpenSS is hinted de
 #some tests require python
 find_package(PythonInterp 3 REQUIRED)
 
-# at present we are going to ignore all packaging paraphernalia.
+if(NOT TINYXML2_LIB_NAME)
+    if(TARGET tinyxml2)
+        set(TINYXML2_LIB_NAME tinyxml2)
+    elseif(TARGET tinyxml2::tinyxml2)
+        set(TINYXML2_LIB_NAME tinyxml2::tinyxml2)  
+    else()
+        message(ERROR "Non standard tinyxml2 target name. Please TINYXML2_LIB_NAME to current targets name.")
+    endif()
+endif()
+
+# OpenSSL isn't mandatory
+if(TARGET OpenSSL::SSL)
+    set(OPENSSL_TARGET OpenSSL::SSL)
+else()
+    unset(OPENSSL_TARGET)
+    unset(OPENSSL_INCLUDE_DIR CACHE)
+endif()
 
 ###############################################################################
 # Logging
@@ -239,20 +255,10 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 #    target_compile_options(${PROJECT_NAME} PRIVATE	-wd4251)
 #endif()
 
-if(NOT TINYXML2_LIB_NAME)
-    if(TARGET tinyxml2)
-        set(TINYXML2_LIB_NAME tinyxml2)
-    elseif(TARGET tinyxml2::tinyxml2)
-        set(TINYXML2_LIB_NAME tinyxml2::tinyxml2)  
-    else()
-        message(ERROR "Non standard tinyxml2 target name. Please TINYXML2_LIB_NAME to current targets name.")
-    endif()
-endif()
-
 # we link dynamically to tinyxml2
 target_link_libraries(${PROJECT_NAME} PUBLIC fastrtps fastcdr 
 	${TINYXML2_LIB_NAME}
-	OpenSSL::SSL 
+	${OPENSSL_TARGET}
 	)
 # note that future versions of tinyxml2 will define the target as tinyxml2::tinyxml2 
 


### PR DESCRIPTION
Basically we must prevent OpenSSL target from being link if it doesn't exist and so for the include dirs:
```
        if(NOT TINYXML2_LIB_NAME)
            if(TARGET tinyxml2)
                set(TINYXML2_LIB_NAME tinyxml2)
            elseif(TARGET tinyxml2::tinyxml2)
                set(TINYXML2_LIB_NAME tinyxml2::tinyxml2)  
            else()
                message(ERROR "Non standard tinyxml2 target name. Please TINYXML2_LIB_NAME to current targets name.")
            endif()
        endif()

        # OpenSSL isn't mandatory
        if(TARGET OpenSSL::SSL)
            set(OPENSSL_TARGET OpenSSL::SSL)
        else()
            unset(OPENSSL_TARGET)
            unset(OPENSSL_INCLUDE_DIR CACHE)
        endif()
```
        
There is a subtetly here. Because FindOpenSSL uses mark_as_advanced(OPENSSL_INCLUDE_DIR OPENSSL_LIBRARIES) then those variables are automatically promoted to CACHE ones and cannot be unset if CACHE is not specified.