### PR TITLE
Add discovery timestamp to snapshots [8131]

### DIFF
--- a/include/IDs.h
+++ b/include/IDs.h
@@ -65,6 +65,7 @@ static const std::string s_sTopic("topic");
 static const std::string s_sType("type");
 static const std::string s_sAliveCount("alive_count");
 static const std::string s_sNotAliveCount("not_alive_count");
+static const std::string s_sDiscovered_timestamp("discovered_timestamp");
 
 } // fastrtps
 } // discovery_server


### PR DESCRIPTION
This PR add a discovery timepstamp, in milliseconds since process start, to all discovered entities. This timestamp is also added to the snapshot XML files as a `discovered_timestamp` attribute of `ptdi`, `publisher`, and `subscriber` tags.

Signed-off-by: EduPonz <eduardoponz@eprosima.com>