### PR TITLE
Improving again Snapshot comparison to avoid another special scenario

### DIFF
--- a/include/DI.h
+++ b/include/DI.h
@@ -286,66 +286,19 @@ struct PtDB : public DI, public std::set<PtDI>
     {
         typedef PtDB::iterator wrapped_iterator;
 
-        smart_iterator(const PtDB& cont) : ref_cont_(cont), wrap_it_(cont.begin())
-        {
-            // ignore zombies
-            while( wrap_it_ != cont.end() && !wrap_it_->is_alive )
-            {
-                ++wrap_it_;
-            }
-        }
-
+        smart_iterator(const PtDB& cont);
         smart_iterator(const smart_iterator & it) : ref_cont_(it.ref_cont_), wrap_it_(it.wrap_it_) {}
 
-        smart_iterator operator++()
-        {
-            do
-            {
-                ++wrap_it_;
-            }
-            while( wrap_it_ != ref_cont_.end() && !wrap_it_->is_alive );
+        smart_iterator operator++();
+        smart_iterator operator++(int);
 
-            return *this;
-        }
+        reference operator*() const;
 
-        smart_iterator operator++(int)
-        {
-            smart_iterator tmp(*this);
+	    pointer operator->() const;
+        bool operator==(const smart_iterator& it) const;
+        bool operator!=(const smart_iterator& it) const;
 
-            operator++();
-
-            return tmp;
-        }
-
-        reference operator*() const
-		{
-            return (reference)*wrap_it_;
-		}
-
-	    pointer operator->() const
-		{
-            return &(**this);
-		}
-
-        bool operator==(const smart_iterator& it) const
-        {
-           // note that zombies are skip, that simplifies comparison
-           return wrap_it_ == it.wrap_it_;
-        }
-
-        bool operator!=(const smart_iterator& it) const
-        {
-           // note that zombies are skip, that simplifies comparison
-           return !(*this == it);
-        }
-
-        smart_iterator end() const
-        {
-            // the end iterator matches the wrapped iterator one
-            smart_iterator tmp(ref_cont_);
-            tmp.wrap_it_ = ref_cont_.end();
-            return tmp;
-        }
+        smart_iterator end() const;
 
         const PtDB& ref_cont_;
         wrapped_iterator wrap_it_;
@@ -369,20 +322,9 @@ struct PtDB : public DI, public std::set<PtDI>
     PtDB& operator=(const PtDB&) = default;
     PtDB& operator=(PtDB&&) = default;
 
-    smart_iterator sbegin() const
-    {
-        return smart_iterator(*this);
-    }
-
-    smart_iterator send() const
-    {
-        return smart_iterator(*this).end();
-    }
-
-    size_type real_size() const
-    {
-        return std::distance(sbegin(),send());
-    }
+    smart_iterator sbegin() const;
+    smart_iterator send() const;
+    size_type real_size() const;
 
     size_type CountParticipants() const;
     size_type CountSubscribers() const;

--- a/src/DSManager.cpp
+++ b/src/DSManager.cpp
@@ -1480,16 +1480,12 @@ void DSManager::onParticipantDiscovery(
     case ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
     case ParticipantDiscoveryInfo::DROPPED_PARTICIPANT:
     {
-        // only update the database if alive
         state.RemoveParticipant(participant->getGuid(), partid);
         break;
     }
     default:
         break;
     }
-
-    // note that I ignore DROPPED_PARTICIPANT because it deals with liveliness
-    // and not with discovery messages
 }
 
 void DSManager::onSubscriberDiscovery(

--- a/test/xml/test_06_EDP_UDP.xml.in
+++ b/test/xml/test_06_EDP_UDP.xml.in
@@ -4,36 +4,36 @@
   <!-- This test extends test_5_EDP_UDP.xml by introducing or removing the different entities at different times-->
   
   <servers>
-    <server name="server" profile_name="UDP server" creation_time="1" >
-      <subscriber topic="topic 1" creation_time="3" />
-      <publisher topic="topic 2" creation_time="5" />
+    <server name="server" profile_name="UDP server" creation_time="2" >
+      <subscriber topic="topic 1" creation_time="4" />
+      <publisher topic="topic 2" creation_time="6" />
     </server>
   </servers>
 
   <clients>
-    <client name="client1" profile_name="UDP client" removal_time="16">
-      <subscriber creation_time="7" removal_time="14" /> <!-- defaults to helloworld type -->
-      <subscriber topic="topic 2" creation_time="7" removal_time="14" />
-      <subscriber profile_name="Sub 1" creation_time="7" removal_time="14" />
-      <publisher profile_name="Pub 2" creation_time="12" />    
+    <client name="client1" profile_name="UDP client" removal_time="17">
+      <subscriber creation_time="8" removal_time="15" /> <!-- defaults to helloworld type -->
+      <subscriber topic="topic 2" creation_time="8" removal_time="15" />
+      <subscriber profile_name="Sub 1" creation_time="8" removal_time="15" />
+      <publisher profile_name="Pub 2" creation_time="13" />    
     </client>
-  <client name="client2" profile_name="UDP client" creation_time="9">
-      <publisher creation_time="10" />  <!-- defaults to helloworld type -->
-      <publisher topic="topic 1" creation_time="10" />
-      <publisher profile_name="Pub 1" creation_time="10" />
-      <subscriber profile_name="Sub 2" creation_time="10" />
+  <client name="client2" profile_name="UDP client" creation_time="10">
+      <publisher creation_time="11" />  <!-- defaults to helloworld type -->
+      <publisher topic="topic 1" creation_time="11" />
+      <publisher profile_name="Pub 1" creation_time="11" />
+      <subscriber profile_name="Sub 2" creation_time="11" />
     </client>
   </clients>
 
   <snapshots>
-      <snapshot time="2">Check client1 detects the server</snapshot>
-      <snapshot time="4">Check client1 detects server's subscriber</snapshot>
-      <snapshot time="6">Check client1 detects server's publisher</snapshot>
-      <snapshot time="8">Check server detects client1's subscribers</snapshot>
-      <snapshot time="11">Check server and client1 detects client2's and its entities</snapshot>
-      <snapshot time="13">Check everybody detects new client1's publisher</snapshot>
-      <snapshot time="15">Check everybody detects client1's subscribers' removal</snapshot>
-      <snapshot time="17" someone="false">Check server and client2 detects client1 removal</snapshot>
+      <snapshot time="3">Check client1 detects the server</snapshot>
+      <snapshot time="5">Check client1 detects server's subscriber</snapshot>
+      <snapshot time="7">Check client1 detects server's publisher</snapshot>
+      <snapshot time="9">Check server detects client1's subscribers</snapshot>
+      <snapshot time="12">Check server and client1 detects client2's and its entities</snapshot>
+      <snapshot time="14">Check everybody detects new client1's publisher</snapshot>
+      <snapshot time="16">Check everybody detects client1's subscribers' removal</snapshot>
+      <snapshot time="18" someone="false">Check server and client2 detects client1 removal</snapshot>
   </snapshots>
   
   <profiles>


### PR DESCRIPTION
Testing long time discovery on the raspberry farm several issues were discovered with zombie participants, that is, those whose DATA(U[p]) are received before any DATA(U[r|w]) associated with them.

I wonder why it didn't happen before on Windows and Ubuntu, note that endpoints are destroyed before the participant and its messages should be delivered before avoiding zombie participants especially on localhost but we have no guarantee on message order reception.

I realized this case is unlikely. The server delivers the messages to the clients, thus, is fairly
probable they will be delivered in the server received order but that's not guaranteed because PDP and EDP messages don't share writers.

I must modify the Snapshot comparison function to ignore the zombies. That implied the creation of a special iterator that ignores zombie participants.
