### PR TITLE
New default prefix

### DIFF
--- a/test/configuration/test_cases/test_22_environment_variable_setup.xml
+++ b/test/configuration/test_cases/test_22_environment_variable_setup.xml
@@ -46,7 +46,7 @@
 
         <participant profile_name="UDP_server">
             <rtps>
-                <prefix>44.49.53.43.53.45.52.56.45.52.5F.30</prefix>
+                <prefix>44.53.00.5f.45.50.52.4f.53.49.4d.41</prefix>
                 <builtin>
                     <discovery_config>
                         <clientAnnouncementPeriod>

--- a/test/configuration/test_cases/test_23_fast_discovery_server_tool.xml
+++ b/test/configuration/test_cases/test_23_fast_discovery_server_tool.xml
@@ -30,7 +30,7 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
+                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
                                 <metatrafficUnicastLocatorList>
                                     <locator>
                                         <udpv4>
@@ -53,7 +53,7 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
+                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
                                 <metatrafficUnicastLocatorList>
                                     <locator>
                                         <udpv4>
@@ -76,7 +76,7 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
+                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
                                 <metatrafficUnicastLocatorList>
                                     <locator>
                                         <udpv4>
@@ -99,7 +99,7 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
+                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
                                 <metatrafficUnicastLocatorList>
                                     <locator>
                                         <udpv4>

--- a/test/configuration/test_solutions/test_22_environment_variable_setup.snapshot
+++ b/test/configuration/test_solutions/test_22_environment_variable_setup.snapshot
@@ -2,23 +2,23 @@
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
     <DS_Snapshot timestamp="1603967909937" process_time="10000" last_pdp_callback_time="141" last_edp_callback_time="0" someone="true">
         <description>test_22_environment_variable_setup_snapshot_1</description>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.30" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1">
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="18"/>
             <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="27"/>
             <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="36"/>
             <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="38"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.30" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="140"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="140"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.30" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="140"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="140"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.30" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="140"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="140"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.30" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="141"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="141"/>
         </ptdb>
     </DS_Snapshot>
 </DS_Snapshots>

--- a/test/configuration/test_solutions/test_23_fast_discovery_server_tool.snapshot
+++ b/test/configuration/test_solutions/test_23_fast_discovery_server_tool.snapshot
@@ -3,7 +3,7 @@
     <DS_Snapshot timestamp="1604570304823" process_time="5000" last_pdp_callback_time="1012" last_edp_callback_time="2461" someone="true">
         <description>test_23_fast_discovery_server_tool_snapshot_1</description>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="1" discovered_timestamp="107"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="1" discovered_timestamp="107"/>
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="11">
                 <publisher type="sample_type_1" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="11"/>
             </ptdi>
@@ -12,7 +12,7 @@
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="1" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="1" discovered_timestamp="124"/>
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="1012">
                 <publisher type="sample_type_1" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2461"/>
             </ptdi>
@@ -21,7 +21,7 @@
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="1" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="1" discovered_timestamp="124"/>
             <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="19">
                 <publisher type="sample_type_1" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="19"/>
             </ptdi>
@@ -30,7 +30,7 @@
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="1" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="1" discovered_timestamp="124"/>
             <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="1012">
                 <publisher type="sample_type_1" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2461"/>
             </ptdi>

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -889,7 +889,7 @@
                     "kill_time": 6,
                     "tool_config":
                     {
-                        "id" : 1,
+                        "id" : 0,
                         "address": "127.0.0.1",
                         "port": 23811
                     },


### PR DESCRIPTION
Merge after #24 

eProsima/Fast-DDS#1764 changes the default server guid prefix. This PRs addresses the change on affected tests