### PR TITLE
Fix backwards compatibility

### DIFF
--- a/include/DSManager.h
+++ b/include/DSManager.h
@@ -145,9 +145,11 @@ class DSManager
 
 public:
     DSManager(const std::string& xml_file_path, const bool shared_memory_off);
+#if FASTRTPS_VERSION_MAJOR >= 2 && FASTRTPS_VERSION_MINOR >=2
     FASTDDS_DEPRECATED_UNTIL(3, "eprosima::discovery_server::DSManager(const std::set<std::string>& xml_snapshot_files,"
             "const std::string & output_file)",
             "Old Discovery Server v1 constructor to validate.")
+#endif
     DSManager(const std::set<std::string>& xml_snapshot_files,
         const std::string & output_file);
     ~DSManager();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ int main(int argc, char * argv[])
     Log::SetVerbosity(Log::Kind::Error);
     // Log::SetCategoryFilter(std::regex("(INTRAPROCESS)"));
 
+#if FASTRTPS_VERSION_MAJOR >= 2 && FASTRTPS_VERSION_MINOR >= 1
     // Create a StdoutErrConsumer consumer that logs entries to stderr only when the Log::Kind is equal to WARNING
     // This allows the test validate the output of the executions
     std::unique_ptr<eprosima::fastdds::dds::StdoutErrConsumer> stdouterr_consumer(
@@ -56,6 +57,7 @@ int main(int argc, char * argv[])
 
     // Register the consumer
     Log::RegisterConsumer(std::move(stdouterr_consumer));
+#endif
 
     // skip program name argv[0] if present
     argc -= (argc > 0);


### PR DESCRIPTION
`feature/discovery-server/unify-test-v2` branch contains the tests for Discovery Server v2.0.
This branch lost backwards compatibility with Fast DDS <2.0.x> and <2.1.x>.