### PR TITLE
[10885] Extend HelloWorldExample to support wan testing

### DIFF
--- a/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
@@ -41,7 +41,8 @@ HelloWorldPublisher::HelloWorldPublisher()
 
 }
 
-bool HelloWorldPublisher::init(Locator_t server_address)
+bool HelloWorldPublisher::init(
+        Locator_t server_address)
 {
     m_hello.index(0);
     m_hello.message("HelloWorld");
@@ -56,10 +57,10 @@ bool HelloWorldPublisher::init(Locator_t server_address)
 
     uint16_t default_port = IPLocator::getPhysicalPort(server_address.port);
 
-    if(server_address.kind == LOCATOR_KIND_TCPv4 ||
-        server_address.kind == LOCATOR_KIND_TCPv6)
+    if (server_address.kind == LOCATOR_KIND_TCPv4 ||
+            server_address.kind == LOCATOR_KIND_TCPv6)
     {
-        if(!IsAddressDefined(server_address))
+        if (!IsAddressDefined(server_address))
         {
             server_address.kind = LOCATOR_KIND_TCPv4;
             IPLocator::setIPv4(server_address, 127, 0, 0, 1);
@@ -72,7 +73,7 @@ bool HelloWorldPublisher::init(Locator_t server_address)
         {
             // clean the client wan from server locator
             Locator_t address(server_address);
-            IPLocator::setWan(address,0,0,0,0);
+            IPLocator::setWan(address, 0, 0, 0, 0);
             ratt.metatrafficUnicastLocatorList.push_back(address);
             PParam.rtps.builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
         }
@@ -96,7 +97,7 @@ bool HelloWorldPublisher::init(Locator_t server_address)
     }
     else
     {
-        if(!IsAddressDefined(server_address))
+        if (!IsAddressDefined(server_address))
         {
             server_address.kind = LOCATOR_KIND_UDPv4;
             server_address.port = default_port;
@@ -115,7 +116,7 @@ bool HelloWorldPublisher::init(Locator_t server_address)
     }
 
     //REGISTER THE TYPE
-    Domain::registerType(mp_participant,&m_type);
+    Domain::registerType(mp_participant, &m_type);
 
     //CREATE THE PUBLISHER
     PublisherAttributes Wparam;
@@ -129,7 +130,7 @@ bool HelloWorldPublisher::init(Locator_t server_address)
     Wparam.times.heartbeatPeriod.seconds = 2;
     Wparam.times.heartbeatPeriod.nanosec = 0;
     Wparam.qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
-    mp_publisher = Domain::createPublisher(mp_participant,Wparam,(PublisherListener*)&m_listener);
+    mp_publisher = Domain::createPublisher(mp_participant, Wparam, (PublisherListener*)&m_listener);
 
     if (mp_publisher == nullptr)
     {
@@ -146,8 +147,8 @@ HelloWorldPublisher::~HelloWorldPublisher()
 }
 
 void HelloWorldPublisher::PubListener::onPublicationMatched(
-    Publisher* /*pub*/,
-    MatchingInfo& info)
+        Publisher* /*pub*/,
+        MatchingInfo& info)
 {
     if (info.status == MATCHED_MATCHING)
     {
@@ -163,23 +164,24 @@ void HelloWorldPublisher::PubListener::onPublicationMatched(
 }
 
 void HelloWorldPublisher::runThread(
-    uint32_t samples,
-    uint32_t sleep)
+        uint32_t samples,
+        uint32_t sleep)
 {
     if (samples == 0)
     {
-        while(!stop)
+        while (!stop)
         {
             if (publish(false))
             {
-                std::cout << "Message: " << m_hello.message() << " with index: " << m_hello.index() << " SENT" << std::endl;
+                std::cout << "Message: " << m_hello.message() << " with index: " << m_hello.index() << " SENT" <<
+                        std::endl;
             }
             std::this_thread::sleep_for(std::chrono::duration<uint32_t, std::milli>(sleep));
         }
     }
     else
     {
-        for(uint32_t i = 0;i<samples;++i)
+        for (uint32_t i = 0; i < samples; ++i)
         {
             if (!publish())
             {
@@ -187,16 +189,17 @@ void HelloWorldPublisher::runThread(
             }
             else
             {
-                std::cout << "Message: " << m_hello.message() << " with index: " << m_hello.index() << " SENT" << std::endl;
+                std::cout << "Message: " << m_hello.message() << " with index: " << m_hello.index() << " SENT" <<
+                        std::endl;
             }
-            std::this_thread::sleep_for(std::chrono::duration<uint32_t,std::milli>(sleep));
+            std::this_thread::sleep_for(std::chrono::duration<uint32_t, std::milli>(sleep));
         }
     }
 }
 
 void HelloWorldPublisher::run(
-    uint32_t samples,
-    uint32_t sleep)
+        uint32_t samples,
+        uint32_t sleep)
 {
     stop = false;
     std::thread thread(&HelloWorldPublisher::runThread, this, samples, sleep);
@@ -213,11 +216,12 @@ void HelloWorldPublisher::run(
     thread.join();
 }
 
-bool HelloWorldPublisher::publish(bool waitForListener)
+bool HelloWorldPublisher::publish(
+        bool waitForListener)
 {
-    if (m_listener.firstConnected || !waitForListener || m_listener.n_matched>0)
+    if (m_listener.firstConnected || !waitForListener || m_listener.n_matched > 0)
     {
-        m_hello.index(m_hello.index()+1);
+        m_hello.index(m_hello.index() + 1);
         mp_publisher->write((void*)&m_hello);
         return true;
     }

--- a/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
@@ -69,11 +69,22 @@ bool HelloWorldPublisher::init(Locator_t server_address)
         IPLocator::setPhysicalPort(server_address, default_port);
         IPLocator::setLogicalPort(server_address, 65215);
 
-        ratt.metatrafficUnicastLocatorList.push_back(server_address);
-        PParam.rtps.builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
+        {
+            // clean the client wan from server locator
+            Locator_t address(server_address);
+            IPLocator::setWan(address,0,0,0,0);
+            ratt.metatrafficUnicastLocatorList.push_back(address);
+            PParam.rtps.builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
+        }
 
         PParam.rtps.useBuiltinTransports = false;
         std::shared_ptr<TCPv4TransportDescriptor> descriptor = std::make_shared<TCPv4TransportDescriptor>();
+
+        // set up wan if provided public address
+        if (IPLocator::hasWan(server_address))
+        {
+            descriptor->set_WAN_address(IPLocator::toWanstring(server_address));
+        }
 
         // Generate a listening port for the client
         std::default_random_engine gen(System::GetPID());

--- a/examples/HelloWorldExampleDS/HelloWorldServer.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldServer.cpp
@@ -34,7 +34,8 @@ HelloWorldServer::HelloWorldServer()
 {
 }
 
-bool HelloWorldServer::init(Locator_t server_address)
+bool HelloWorldServer::init(
+        Locator_t server_address)
 {
     ParticipantAttributes PParam;
     PParam.rtps.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
@@ -48,7 +49,7 @@ bool HelloWorldServer::init(Locator_t server_address)
     // all local interfaces
 
     if (server_address.kind == LOCATOR_KIND_TCPv4 ||
-        server_address.kind == LOCATOR_KIND_TCPv6)
+            server_address.kind == LOCATOR_KIND_TCPv6)
     {
 
         // logical port cannot be customize in this example
@@ -59,7 +60,7 @@ bool HelloWorldServer::init(Locator_t server_address)
 
         std::shared_ptr<TCPTransportDescriptor> descriptor;
 
-        if(server_address.kind == LOCATOR_KIND_TCPv4)
+        if (server_address.kind == LOCATOR_KIND_TCPv4)
         {
             auto tcpv4_descriptor = std::make_shared<TCPv4TransportDescriptor>();
 
@@ -88,8 +89,10 @@ bool HelloWorldServer::init(Locator_t server_address)
     }
 
     mp_participant = Domain::createParticipant(PParam);
-    if (mp_participant==nullptr)
+    if (mp_participant == nullptr)
+    {
         return false;
+    }
 
     return true;
 }
@@ -99,10 +102,8 @@ HelloWorldServer::~HelloWorldServer()
     Domain::removeParticipant(mp_participant);
 }
 
-
 void HelloWorldServer::run()
 {
     std::cout << "Server running. Please press enter to stop the server" << std::endl;
     std::cin.ignore();
 }
-

--- a/examples/HelloWorldExampleDS/HelloWorldServer.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldServer.cpp
@@ -61,7 +61,15 @@ bool HelloWorldServer::init(Locator_t server_address)
 
         if(server_address.kind == LOCATOR_KIND_TCPv4)
         {
-            descriptor = std::make_shared<TCPv4TransportDescriptor>();
+            auto tcpv4_descriptor = std::make_shared<TCPv4TransportDescriptor>();
+
+            // set up wan if provided public address
+            if (IPLocator::hasWan(server_address))
+            {
+                tcpv4_descriptor->set_WAN_address(IPLocator::toWanstring(server_address));
+            }
+
+            descriptor = tcpv4_descriptor;
         }
         else
         {

--- a/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
@@ -64,11 +64,22 @@ bool HelloWorldSubscriber::init(Locator_t server_address)
         IPLocator::setLogicalPort(server_address, 65215);
         IPLocator::setPhysicalPort(server_address, default_port);
 
-        ratt.metatrafficUnicastLocatorList.push_back(server_address);
-        PParam.rtps.builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
+        {
+            // clean the client wan from server locator
+            Locator_t address(server_address);
+            IPLocator::setWan(address,0,0,0,0);
+            ratt.metatrafficUnicastLocatorList.push_back(address);
+            PParam.rtps.builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
+        }
 
         PParam.rtps.useBuiltinTransports = false;
         std::shared_ptr<TCPv4TransportDescriptor> descriptor = std::make_shared<TCPv4TransportDescriptor>();
+
+        // set up wan if provided public address
+        if (IPLocator::hasWan(server_address))
+        {
+            descriptor->set_WAN_address(IPLocator::toWanstring(server_address));
+        }
 
         // Generate a listening port for the client
         std::default_random_engine gen(System::GetPID());

--- a/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
@@ -38,7 +38,8 @@ HelloWorldSubscriber::HelloWorldSubscriber()
 {
 }
 
-bool HelloWorldSubscriber::init(Locator_t server_address)
+bool HelloWorldSubscriber::init(
+        Locator_t server_address)
 {
 
     RemoteServerAttributes ratt;
@@ -51,10 +52,10 @@ bool HelloWorldSubscriber::init(Locator_t server_address)
 
     uint16_t default_port = IPLocator::getPhysicalPort(server_address.port);
 
-    if(server_address.kind == LOCATOR_KIND_TCPv4 ||
-        server_address.kind == LOCATOR_KIND_TCPv6)
+    if (server_address.kind == LOCATOR_KIND_TCPv4 ||
+            server_address.kind == LOCATOR_KIND_TCPv6)
     {
-        if(!IsAddressDefined(server_address))
+        if (!IsAddressDefined(server_address))
         {
             server_address.kind = LOCATOR_KIND_TCPv4;
             IPLocator::setIPv4(server_address, 127, 0, 0, 1);
@@ -67,7 +68,7 @@ bool HelloWorldSubscriber::init(Locator_t server_address)
         {
             // clean the client wan from server locator
             Locator_t address(server_address);
-            IPLocator::setWan(address,0,0,0,0);
+            IPLocator::setWan(address, 0, 0, 0, 0);
             ratt.metatrafficUnicastLocatorList.push_back(address);
             PParam.rtps.builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
         }
@@ -91,7 +92,7 @@ bool HelloWorldSubscriber::init(Locator_t server_address)
     }
     else
     {
-        if(!IsAddressDefined(server_address))
+        if (!IsAddressDefined(server_address))
         {
             server_address.kind = LOCATOR_KIND_UDPv4;
             server_address.port = default_port;
@@ -111,7 +112,7 @@ bool HelloWorldSubscriber::init(Locator_t server_address)
 
     //REGISTER THE TYPE
 
-    Domain::registerType(mp_participant,&m_type);
+    Domain::registerType(mp_participant, &m_type);
     //CREATE THE SUBSCRIBER
     SubscriberAttributes Rparam;
     Rparam.topic.topicKind = NO_KEY;
@@ -123,7 +124,7 @@ bool HelloWorldSubscriber::init(Locator_t server_address)
     Rparam.topic.resourceLimitsQos.allocated_samples = 20;
     Rparam.qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
     Rparam.qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-    mp_subscriber = Domain::createSubscriber(mp_participant,Rparam,(SubscriberListener*)&m_listener);
+    mp_subscriber = Domain::createSubscriber(mp_participant, Rparam, (SubscriberListener*)&m_listener);
 
     if (mp_subscriber == nullptr)
     {
@@ -139,8 +140,8 @@ HelloWorldSubscriber::~HelloWorldSubscriber()
 }
 
 void HelloWorldSubscriber::SubListener::onSubscriptionMatched(
-    Subscriber* /*sub*/,
-    MatchingInfo& info)
+        Subscriber* /*sub*/,
+        MatchingInfo& info)
 {
     if (info.status == MATCHED_MATCHING)
     {
@@ -154,7 +155,8 @@ void HelloWorldSubscriber::SubListener::onSubscriptionMatched(
     }
 }
 
-void HelloWorldSubscriber::SubListener::onNewDataMessage(Subscriber* sub)
+void HelloWorldSubscriber::SubListener::onNewDataMessage(
+        Subscriber* sub)
 {
     if (sub->takeNextData((void*)&m_hello, &m_info))
     {
@@ -162,7 +164,7 @@ void HelloWorldSubscriber::SubListener::onNewDataMessage(Subscriber* sub)
         {
             this->n_samples++;
             // Print your structure data here.
-            std::cout << "Message " << m_hello.message() << " "<< m_hello.index() << " RECEIVED" <<std::endl;
+            std::cout << "Message " << m_hello.message() << " " << m_hello.index() << " RECEIVED" << std::endl;
         }
     }
 
@@ -174,7 +176,8 @@ void HelloWorldSubscriber::run()
     std::cin.ignore();
 }
 
-void HelloWorldSubscriber::run(uint32_t number)
+void HelloWorldSubscriber::run(
+        uint32_t number)
 {
     std::cout << "Subscriber running until " << number << "samples have been received" << std::endl;
     while (number > this->m_listener.n_samples)

--- a/examples/HelloWorldExampleDS/HelloWorld_main.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorld_main.cpp
@@ -31,29 +31,46 @@
 
 struct Arg : public option::Arg
 {
-    static void print_error(const char* msg1, const option::Option& opt, const char* msg2)
+    static void print_error(
+            const char* msg1,
+            const option::Option& opt,
+            const char* msg2)
     {
         fprintf(stderr, "%s", msg1);
         fwrite(opt.name, opt.namelen, 1, stderr);
         fprintf(stderr, "%s", msg2);
     }
 
-    static option::ArgStatus Unknown(const option::Option& option, bool msg)
+    static option::ArgStatus Unknown(
+            const option::Option& option,
+            bool msg)
     {
-        if (msg) print_error("Unknown option '", option, "'\n");
+        if (msg)
+        {
+            print_error("Unknown option '", option, "'\n");
+        }
         return option::ARG_ILLEGAL;
     }
 
-    static option::ArgStatus Required(const option::Option& option, bool msg)
+    static option::ArgStatus Required(
+            const option::Option& option,
+            bool msg)
     {
         if (option.arg != 0 && option.arg[0] != 0)
+        {
             return option::ARG_OK;
+        }
 
-        if (msg) print_error("Option '", option, "' requires an argument\n");
+        if (msg)
+        {
+            print_error("Option '", option, "' requires an argument\n");
+        }
         return option::ARG_ILLEGAL;
     }
 
-    static option::ArgStatus Numeric(const option::Option& option, bool msg)
+    static option::ArgStatus Numeric(
+            const option::Option& option,
+            bool msg)
     {
         char* endptr = 0;
         if (option.arg != 0 && strtol(option.arg, &endptr, 10))
@@ -71,13 +88,15 @@ struct Arg : public option::Arg
         return option::ARG_ILLEGAL;
     }
 
-    static option::ArgStatus Locator(const option::Option& option, bool msg)
+    static option::ArgStatus Locator(
+            const option::Option& option,
+            bool msg)
     {
         if (option.arg != 0)
         {
             // we must check if its a correct ip address plus port number
-            if(std::regex_match(option.arg, ipv4)
-                || std::regex_match(option.arg, ipv6))
+            if (std::regex_match(option.arg, ipv4)
+                    || std::regex_match(option.arg, ipv6))
             {
                 return option::ARG_OK;
             }
@@ -92,7 +111,8 @@ struct Arg : public option::Arg
     static const std::regex wan, ipv4, ipv6;
 };
 
-enum  optionIndex {
+enum  optionIndex
+{
     UNKNOWN_OPT,
     HELP,
     SAMPLES,
@@ -103,19 +123,19 @@ enum  optionIndex {
 };
 
 const option::Descriptor usage[] = {
-    { UNKNOWN_OPT, 0,"", "",                Arg::None,
-        "Usage: HelloWorldExampleDS <publisher|subscriber|server>\n\nGeneral options:" },
-    { HELP,    0,"h", "help",               Arg::None,      "  -h \t--help  \tProduce help message." },
-    { TCP,0,"t","tcp",                   Arg::None,
-        "  -t \t--tcp \tUse tcp transport instead of the default UDP one." },
-    { SAMPLES,0,"c","count",              Arg::Numeric,
-        "  -c <num>, \t--count=<num>  \tNumber of datagrams to send (0 = infinite) defaults to 10." },
-    { INTERVAL,0,"i","interval",            Arg::Numeric,
-        "  -i <num>, \t--interval=<num>  \tTime between samples in milliseconds (Default: 100)." },
+    { UNKNOWN_OPT, 0, "", "",                Arg::None,
+      "Usage: HelloWorldExampleDS <publisher|subscriber|server>\n\nGeneral options:" },
+    { HELP,    0, "h", "help",               Arg::None,      "  -h \t--help  \tProduce help message." },
+    { TCP, 0, "t", "tcp",                   Arg::None,
+      "  -t \t--tcp \tUse tcp transport instead of the default UDP one." },
+    { SAMPLES, 0, "c", "count",              Arg::Numeric,
+      "  -c <num>, \t--count=<num>  \tNumber of datagrams to send (0 = infinite) defaults to 10." },
+    { INTERVAL, 0, "i", "interval",            Arg::Numeric,
+      "  -i <num>, \t--interval=<num>  \tTime between samples in milliseconds (Default: 100)." },
     { LOCATOR, 0, "l", "ip",                Arg::Locator,
-        "  -l <IPaddress[:port number]>, \t--ip=<IPaddress[:port number]>  \tServer address." },
+      "  -l <IPaddress[:port number]>, \t--ip=<IPaddress[:port number]>  \tServer address." },
     { WAN, 0, "w", "wan",                Arg::Locator,
-        "  -w <IPaddress>, \t--wan=<IPaddress]>  \tnetwork wan address." },
+      "  -w <IPaddress>, \t--wan=<IPaddress]>  \tnetwork wan address." },
     { 0, 0, 0, 0, 0, 0 }
 };
 
@@ -126,27 +146,29 @@ const option::Descriptor usage[] = {
 using namespace eprosima;
 using namespace fastrtps;
 using namespace rtps;
-int main(int argc, char** argv)
+int main(
+        int argc,
+        char** argv)
 {
     int columns;
 
     #if defined(_WIN32)
-        char* buf = nullptr;
-        size_t sz = 0;
-        if (_dupenv_s(&buf, &sz, "COLUMNS") == 0 && buf != nullptr)
-        {
-            columns = strtol(buf, nullptr, 10);
-            free(buf);
-        }
-        else
-        {
-            columns = 80;
-        }
+    char* buf = nullptr;
+    size_t sz = 0;
+    if (_dupenv_s(&buf, &sz, "COLUMNS") == 0 && buf != nullptr)
+    {
+        columns = strtol(buf, nullptr, 10);
+        free(buf);
+    }
+    else
+    {
+        columns = 80;
+    }
     #else
-        columns = getenv("COLUMNS") ? atoi(getenv("COLUMNS")) : 80;
-    #endif
+    columns = getenv("COLUMNS") ? atoi(getenv("COLUMNS")) : 80;
+    #endif // if defined(_WIN32)
 
-    std::cout << "Starting "<< std::endl;
+    std::cout << "Starting " << std::endl;
     int type = 1;
     int count = 20;
     long sleep = 100;
@@ -154,7 +176,7 @@ int main(int argc, char** argv)
     std::string wan_address;
     server_address.port = 60006; // default physical port
 
-    if(argc > 1)
+    if (argc > 1)
     {
         if (strcmp(argv[1], "publisher") == 0)
         {
@@ -192,99 +214,99 @@ int main(int argc, char** argv)
             option::Option& opt = buffer[i];
             switch (opt.index())
             {
-            case HELP:
-                option::printUsage(fwrite, stdout, usage, columns);
-                return 0;
+                case HELP:
+                    option::printUsage(fwrite, stdout, usage, columns);
+                    return 0;
 
-            case SAMPLES:
-                count = strtol(opt.arg, nullptr, 10);
-                break;
+                case SAMPLES:
+                    count = strtol(opt.arg, nullptr, 10);
+                    break;
 
-            case INTERVAL:
-                sleep = strtol(opt.arg, nullptr, 10);
-                break;
+                case INTERVAL:
+                    sleep = strtol(opt.arg, nullptr, 10);
+                    break;
 
-            // remember that options can be parsed in any order
-            case TCP:
-            {
-                // locators default to LOCATOR_KIND_UDPv4
-                // promote from UDP to TCP
-                if(IsAddressDefined(server_address))
+                // remember that options can be parsed in any order
+                case TCP:
                 {
-                    server_address.kind =
-                        ( server_address.kind == LOCATOR_KIND_UDPv4 ) ? LOCATOR_KIND_TCPv4 : LOCATOR_KIND_TCPv6;
-                }
-                else
-                {
-                    server_address.kind = LOCATOR_KIND_TCPv4;
-                }
-
-                break;
-            }
-
-            case LOCATOR:
-            {
-                std::cmatch mr;
-                std::string ip_address;
-                uint16_t port = server_address.port;
-                bool v4 = true;
-
-                if((v4 = regex_match(opt.arg, mr, Arg::ipv4))
-                    || regex_match(opt.arg, mr, Arg::ipv6))
-                {
-                    std::cmatch::iterator it = mr.cbegin();
-                    ip_address = (++it)->str();
-
-                    if((++it)->matched)
+                    // locators default to LOCATOR_KIND_UDPv4
+                    // promote from UDP to TCP
+                    if (IsAddressDefined(server_address))
                     {
-                        port = std::stoi(it->str());
-                    }
-                }
-
-                // promote to v6 if needed
-                if(!v4)
-                {
-                    server_address.kind =
-                        (server_address.kind == LOCATOR_KIND_UDPv4) ? LOCATOR_KIND_UDPv6 : LOCATOR_KIND_TCPv6;
-                }
-
-                if(!ip_address.empty() && port > 1000)
-                {
-                    IPLocator::setPhysicalPort(server_address, port);
-                    if(v4)
-                    {
-                        IPLocator::setIPv4(server_address, ip_address);
+                        server_address.kind =
+                                ( server_address.kind == LOCATOR_KIND_UDPv4 ) ? LOCATOR_KIND_TCPv4 : LOCATOR_KIND_TCPv6;
                     }
                     else
                     {
-                        IPLocator::setIPv6(server_address, ip_address);
+                        server_address.kind = LOCATOR_KIND_TCPv4;
                     }
+
+                    break;
                 }
 
-                break;
-            }
-
-            case WAN:
-            {
-                std::cmatch mr;
-
-                if(regex_match(opt.arg, mr, Arg::wan))
+                case LOCATOR:
                 {
-                    std::cmatch::iterator it = mr.cbegin();
-                    wan_address = (++it)->str();
-                }
-                else
-                {
-                    std::cout << "CLI error: Wan address must be Ipv4" << std::endl;
-                    return -1;
-                }
-                break;
-            }
+                    std::cmatch mr;
+                    std::string ip_address;
+                    uint16_t port = server_address.port;
+                    bool v4 = true;
 
-            case UNKNOWN_OPT:
-                option::printUsage(fwrite, stdout, usage, columns);
-                return 0;
-                break;
+                    if ((v4 = regex_match(opt.arg, mr, Arg::ipv4))
+                            || regex_match(opt.arg, mr, Arg::ipv6))
+                    {
+                        std::cmatch::iterator it = mr.cbegin();
+                        ip_address = (++it)->str();
+
+                        if ((++it)->matched)
+                        {
+                            port = std::stoi(it->str());
+                        }
+                    }
+
+                    // promote to v6 if needed
+                    if (!v4)
+                    {
+                        server_address.kind =
+                                (server_address.kind == LOCATOR_KIND_UDPv4) ? LOCATOR_KIND_UDPv6 : LOCATOR_KIND_TCPv6;
+                    }
+
+                    if (!ip_address.empty() && port > 1000)
+                    {
+                        IPLocator::setPhysicalPort(server_address, port);
+                        if (v4)
+                        {
+                            IPLocator::setIPv4(server_address, ip_address);
+                        }
+                        else
+                        {
+                            IPLocator::setIPv6(server_address, ip_address);
+                        }
+                    }
+
+                    break;
+                }
+
+                case WAN:
+                {
+                    std::cmatch mr;
+
+                    if (regex_match(opt.arg, mr, Arg::wan))
+                    {
+                        std::cmatch::iterator it = mr.cbegin();
+                        wan_address = (++it)->str();
+                    }
+                    else
+                    {
+                        std::cout << "CLI error: Wan address must be Ipv4" << std::endl;
+                        return -1;
+                    }
+                    break;
+                }
+
+                case UNKNOWN_OPT:
+                    option::printUsage(fwrite, stdout, usage, columns);
+                    return 0;
+                    break;
             }
         }
 
@@ -292,7 +314,7 @@ int main(int argc, char** argv)
         // - only accept wan argument if locator is tcpv4
         if (!wan_address.empty())
         {
-            if( server_address.kind != LOCATOR_KIND_TCPv4)
+            if ( server_address.kind != LOCATOR_KIND_TCPv4)
             {
                 std::cout << "CLI error: --wan option only over tcpv4" << std::endl;
                 return -1;
@@ -309,26 +331,26 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    switch(type)
+    switch (type)
     {
         case 1:
+        {
+            HelloWorldPublisher mypub;
+            if (mypub.init(server_address))
             {
-                HelloWorldPublisher mypub;
-                if(mypub.init(server_address))
-                {
-                    mypub.run(count, sleep);
-                }
-                break;
+                mypub.run(count, sleep);
             }
+            break;
+        }
         case 2:
+        {
+            HelloWorldSubscriber mysub;
+            if (mysub.init(server_address))
             {
-                HelloWorldSubscriber mysub;
-                if(mysub.init(server_address))
-                {
-                    mysub.run();
-                }
-                break;
+                mysub.run();
             }
+            break;
+        }
         case 3:
         {
             HelloWorldServer myserver;


### PR DESCRIPTION
This was triggered by a Fast-DDS issue [10885](https://github.com/eProsima/Fast-DDS/issues/1790).
Now the `--tcp` flag can be combined with a `--wan` one to specify a computers public IPv4 address. For example:
- WAN network with mask `192.168.36.X`. Here:
    - Subscriber client with address `192.168.36.54`
    - LAN router with address `192.168.36.53`
- LAN network with mast `192.168.42.X`. Here:
    - Server with address `192.168.42.73`
    - Publisher client with address `192.168.42.74`
 
The command line for each participant would be:
```powershell
> HelloWorldExampleDS-d.exe server --tcp --ip=192.168.42.73:5100 --wan=192.168.36.53
> HelloWorldExampleDS-d.exe publisher --tcp --ip=192.168.42.73:5100 --wan=192.168.36.53 -c 30
> HelloWorldExampleDS-d.exe subscriber --tcp --ip=192.168.36.53:5100 --wan=192.168.36.54
```

