### PR TITLE
hotfix for windows testing

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -492,7 +492,7 @@ def execute_validate_test(
     )
 
     # Clear /dev/shm
-    subprocess.call('rm -f /dev/shm/*fastrtps*', shell=True)
+    subprocess.call('fastdds shm clean', shell=True)
 
     return result
 


### PR DESCRIPTION
It was detected that the following tests:

        test_39_trivial_reconnect
        test_40_trivial_server_reconnect
        test_41_reconnect_with_clients
        test_42_server_reconnect_with_clients
        test_43_complex_reconnect
        test_44_fast_discovery_server_tool_reconnect
        test_45_trivial_client_reconnect

are not actually testing crashes but order reconections (wireshark shows the servers that should be crashing send `DATA(Up)`s).
This tests should be review to force actual crashes.

