### PR TITLE
[16440] Avoid static_cast on participant name deduction

### DIFF
--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -1897,7 +1897,9 @@ void DiscoveryServerManager::on_subscriber_discovery(
     if (part_name.empty())
     {
         // if remote use prefix instead of name
-        part_name = static_cast<std::ostringstream>(std::ostringstream() << partid).str();
+        std::ostringstream ss;
+        ss << partid;
+        part_name = ss.str();
     }
 
     switch (info.status)
@@ -1973,7 +1975,9 @@ void DiscoveryServerManager::on_publisher_discovery(
     if (part_name.empty())
     {
         // if remote use prefix instead of name
-        part_name = static_cast<std::ostringstream>(std::ostringstream() << partid).str();
+        std::ostringstream ss;
+        ss << partid;
+        part_name = ss.str();
     }
 
     switch (info.status)


### PR DESCRIPTION
#59 fix compilation in Ubuntu Jammy, but broke it in Ubuntu Focal. This PR fixes both.