### PR TITLE
[20568] Adjust for removing all redundant headers from include/fastrtps

### DIFF
--- a/include/DiscoveryItem.h
+++ b/include/DiscoveryItem.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-#include <fastrtps/rtps/common/Guid.h>
+#include <fastdds/rtps/common/Guid.h>
 
 namespace tinyxml2 {
 class XMLElement;

--- a/src/DSLog.h.in
+++ b/src/DSLog.h.in
@@ -31,11 +31,11 @@
     #undef LOG_NO_ERROR
 #endif
 
-#include <fastrtps/log/Log.h>
+#include <fastdds/dds/log/Log.hpp>
 
-#define LOG(x) logInfo(DISCOVERY_SERVER,x)
-#define LOG_INFO(x) logInfo(DISCOVERY_SERVER,x)
-#define LOG_WARN(x) logWarning(DISCOVERY_SERVER,x)
-#define LOG_ERROR(x) logError(DISCOVERY_SERVER,x)
+#define LOG(x) EPROSIMA_LOG_INFO(DISCOVERY_SERVER,x);
+#define LOG_INFO(x) EPROSIMA_LOG_INFO(DISCOVERY_SERVER,x);
+#define LOG_WARN(x) EPROSIMA_LOG_WARNING(DISCOVERY_SERVER,x;);
+#define LOG_ERROR(x) EPROSIMA_LOG_ERROR(DISCOVERY_SERVER,x);
 
 #endif // _EPROSIMA_IS_LOG_H_


### PR DESCRIPTION
This PR adds support for:
* eprosima/Fast-DDS#4546