### PR TITLE
[20629] GUIDLess Discovery Server

### DIFF
--- a/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
@@ -49,9 +49,7 @@ bool HelloWorldPublisher::init(
     m_hello.index(0);
     m_hello.message("HelloWorld");
 
-    RemoteServerAttributes ratt;
-
-    ratt.ReadguidPrefix("44.49.53.43.53.45.52.56.45.52.5F.31");
+    LocatorList_t remote_server;
 
     DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
 
@@ -70,8 +68,8 @@ bool HelloWorldPublisher::init(
         IPLocator::setPhysicalPort(server_address, default_port);
         IPLocator::setLogicalPort(server_address, 65215);
 
-        ratt.metatrafficUnicastLocatorList.push_back(server_address);
-        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
+        remote_server.push_back(server_address);
+        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(remote_server);
         participant_qos.transport().use_builtin_transports = false;
         std::shared_ptr<TCPv4TransportDescriptor> descriptor = std::make_shared<TCPv4TransportDescriptor>();
 
@@ -90,8 +88,8 @@ bool HelloWorldPublisher::init(
             IPLocator::setIPv4(server_address, 127, 0, 0, 1);
         }
 
-        ratt.metatrafficUnicastLocatorList.push_back(server_address);
-        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
+        remote_server.push_back(server_address);
+        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(remote_server);
     }
 
     participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::CLIENT;

--- a/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
@@ -46,8 +46,7 @@ bool HelloWorldSubscriber::init(
         Locator server_address)
 {
 
-    RemoteServerAttributes ratt;
-    ratt.ReadguidPrefix("44.49.53.43.53.45.52.56.45.52.5F.31");
+    LocatorList_t remote_server;
 
     DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
 
@@ -66,8 +65,8 @@ bool HelloWorldSubscriber::init(
         IPLocator::setPhysicalPort(server_address, default_port);
         IPLocator::setLogicalPort(server_address, 65215);
 
-        ratt.metatrafficUnicastLocatorList.push_back(server_address);
-        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
+        remote_server.push_back(server_address);
+        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(remote_server);
         participant_qos.transport().use_builtin_transports = false;
         std::shared_ptr<TCPv4TransportDescriptor> descriptor = std::make_shared<TCPv4TransportDescriptor>();
 
@@ -86,8 +85,8 @@ bool HelloWorldSubscriber::init(
             IPLocator::setIPv4(server_address, 127, 0, 0, 1);
         }
 
-        ratt.metatrafficUnicastLocatorList.push_back(server_address);
-        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
+        remote_server.push_back(server_address);
+        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(remote_server);
     }
 
     participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::CLIENT;

--- a/include/DiscoveryItem.h
+++ b/include/DiscoveryItem.h
@@ -326,6 +326,8 @@ struct ParticipantDiscoveryDatabase : public DiscoveryItem, public std::set<Part
     typedef std::set<ParticipantDiscoveryItem>::size_type size_type;
     typedef ParticipantDiscoveryDatabase::iterator iterator;
 
+    std::string participant_name_;
+
     // we need a special iterator that ignores zombie members
     struct smart_iterator
         : std::iterator<
@@ -365,8 +367,10 @@ struct ParticipantDiscoveryDatabase : public DiscoveryItem, public std::set<Part
     };
 
     ParticipantDiscoveryDatabase(
-            const GUID_t& id )
+            const GUID_t& id,
+            const std::string& name = std::string())
         : DiscoveryItem(id)
+        , participant_name_(name)
     {
     }
 
@@ -481,6 +485,10 @@ struct Snapshot : public std::set<ParticipantDiscoveryDatabase>
     const ParticipantDiscoveryDatabase* operator [](
             const GUID_t&) const;
 
+    ParticipantDiscoveryDatabase& access_snapshot(
+            const GUID_t& ptid,
+            const std::string& name);
+
     void to_xml(
             tinyxml2::XMLElement* pRoot,
             tinyxml2::XMLDocument& xmlDoc) const;
@@ -508,6 +516,7 @@ class DiscoveryItemDatabase
         class T>
     bool AddEndPoint(T & (ParticipantDiscoveryItem::* m)() const,
             const GUID_t& spokesman,
+            const std::string& srcName,
             const GUID_t& ptid,
             const GUID_t& sid,
             const std::string& _typename,
@@ -542,6 +551,7 @@ public:
     //! Adds a new participant, returns false if allocation fails
     bool AddParticipant(
             const GUID_t& spokesman,
+            const std::string& srcName,
             const GUID_t& ptid,
             const std::string& name = std::string(),
             const std::chrono::steady_clock::time_point& discovered_timestamp = std::chrono::steady_clock::now(),
@@ -559,6 +569,7 @@ public:
     //! Adds a new Subscriber, returns false if allocation fails
     bool AddDataReader(
             const GUID_t& spokesman,
+            const std::string& srcName,
             const GUID_t& ptid,
             const GUID_t& sid,
             const std::string& _typename,
@@ -573,6 +584,7 @@ public:
     //! Adds a new Publisher, returns false if allocation fails
     bool AddDataWriter(
             const GUID_t& spokesman,
+            const std::string& srcName,
             const GUID_t& ptid,
             const GUID_t& pid,
             const std::string& _typename,

--- a/include/IDs.h
+++ b/include/IDs.h
@@ -31,8 +31,6 @@ static const std::string s_sSimples("simples");
 static const std::string s_sSimple("simple");
 static const std::string s_sPersist("persist");
 static const std::string s_sLP("ListeningPorts");
-static const std::string s_sSL("ServersList");
-static const std::string s_sRServer("RServer");
 static const std::string s_sTime("time");
 static const std::string s_sSomeone("someone");
 static const std::string s_sShowLiveliness("show_liveliness");

--- a/resources/xml/test_schema.xml
+++ b/resources/xml/test_schema.xml
@@ -25,16 +25,12 @@
         <builtin>
           <discoveryProtocol>CLIENT</discoveryProtocol>
           <discoveryServersList>
-            <RemoteServer prefix="4D.49.47.55.45.4c.5f.42.41.52.52.4f">
-              <metatrafficUnicastLocatorList>
-                <locator>
-                  <udpv4>
-                    <address>127.0.0.1</address>
-                    <port>65215</port>
-                  </udpv4>
-                </locator>
-              </metatrafficUnicastLocatorList>
-            </RemoteServer>
+              <locator>
+                <udpv4>
+                  <address>127.0.0.1</address>
+                  <port>65215</port>
+                </udpv4>
+              </locator>
           </discoveryServersList>
         </builtin>
       </rtps>

--- a/resources/xml/test_schema2.xml
+++ b/resources/xml/test_schema2.xml
@@ -43,16 +43,12 @@
         <builtin>
           <discoveryProtocol>CLIENT</discoveryProtocol>
           <discoveryServersList>
-            <RemoteServer prefix="4D.49.47.55.45.4c.5f.42.41.52.52.4f">
-              <metatrafficUnicastLocatorList>
-                <locator>
-                  <udpv4>
-                    <address>127.0.0.1</address>
-                    <port>65215</port>
-                  </udpv4>
-                </locator>
-              </metatrafficUnicastLocatorList>
-            </RemoteServer>
+              <locator>
+                <udpv4>
+                  <address>127.0.0.1</address>
+                  <port>65215</port>
+                </udpv4>
+              </locator>
           </discoveryServersList>
         </builtin>
       </rtps>

--- a/resources/xsd/discovery-server.xsd
+++ b/resources/xsd/discovery-server.xsd
@@ -915,7 +915,6 @@
                     </xs:choice>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="ServersList" type="ServersListType" minOccurs="0" maxOccurs="1" />
             <!-- not mandatory may be present in the profile -->
             <xs:choice minOccurs="0">
                 <!-- publisher and subscriber must be contiguous but in any order -->
@@ -942,19 +941,8 @@
         <!-- removal time in seconds from startup-->
     </xs:complexType>
 
-    <xs:complexType name="ServersListType">
-        <xs:sequence>
-            <xs:element name="RServer" minOccurs="1" maxOccurs="unbounded">
-                <xs:complexType>
-                    <xs:attribute name="prefix" type="guid" use="required" />
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-
     <xs:complexType name="clientType">
         <xs:sequence >
-            <xs:element name="ServersList" type="ServersListType" minOccurs="0" maxOccurs="1" />
             <xs:choice minOccurs="0">
                 <!-- publisher and subscriber must be contiguous but in any order -->
                 <xs:sequence>

--- a/resources/xsd/discovery-server.xsd
+++ b/resources/xsd/discovery-server.xsd
@@ -349,12 +349,6 @@
         <xs:attribute name="prefix" type="guid" use="required"/>
     </xs:complexType>
 
-    <xs:complexType name="DiscoveryServerList">
-        <xs:sequence>
-            <xs:element name="RemoteServer" type="RemoteServerAttributes" minOccurs="1" maxOccurs="unbounded"/>
-        </xs:sequence>
-    </xs:complexType>
-
     <xs:complexType name="initialAnnouncementsType">
         <xs:all minOccurs="0">
             <xs:element name="count" type="uint32Type" minOccurs="0"/>
@@ -372,7 +366,7 @@
             <xs:element name="initialAnnouncements" type="initialAnnouncementsType" minOccurs="0"/>
             <xs:element name="simpleEDP" type="simpleEDPType" minOccurs="0"/>
             <xs:element name="clientAnnouncementPeriod" type="durationType" minOccurs="0"/>
-            <xs:element name="discoveryServersList" type="DiscoveryServerList" minOccurs="0"/>
+            <xs:element name="discoveryServersList" type="locatorListType" minOccurs="0"/>
             <xs:element name="staticEndpointXMLFilename" type="stringType" minOccurs="0"/>
         </xs:all>
     </xs:complexType>

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -1566,7 +1566,7 @@ void DiscoveryServerManager::MapServerInfo(
 
     if (prefix == c_GuidPrefix_Unknown)
     {
-        LOG_ERROR("Servers cannot have a framework provided prefix"); // at least for now
+        LOG_INFO("Guidless server, locators must be set directly from the XML");
         return;
     }
 

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -871,43 +871,6 @@ void DiscoveryServerManager::loadServer(
         dpQOS.wire_protocol().builtin.metatrafficUnicastLocatorList = lists.second;
     }
 
-    // load the server list (if present) and update the DomainParticipantQOS builtin
-    tinyxml2::XMLElement* server_list = server->FirstChildElement(s_sSL.c_str());
-
-    if (server_list != nullptr)
-    {
-        RemoteServerList_t& list = dpQOS.wire_protocol().builtin.discovery_config.m_DiscoveryServers;
-        list.clear(); // server elements take precedence over profile ones
-
-        tinyxml2::XMLElement* rserver = server_list->FirstChildElement(s_sRServer.c_str());
-
-        while (rserver != nullptr)
-        {
-            RemoteServerList_t::value_type srv;
-            GuidPrefix_t& prefix = srv.guidPrefix;
-
-            // load the prefix
-            const char* cprefix = rserver->Attribute(DSxmlparser::PREFIX);
-
-            if (cprefix != nullptr &&
-                    !(std::istringstream(cprefix) >> prefix)
-                    && (prefix == c_GuidPrefix_Unknown))
-            {
-                LOG_ERROR("RServers must provide a prefix"); // at least for now
-                return;
-            }
-
-            // load the locator lists
-            serverLocator_map::mapped_type& lists = server_locators[srv.GetParticipant()];
-            srv.metatrafficMulticastLocatorList = lists.first;
-            srv.metatrafficUnicastLocatorList = lists.second;
-
-            list.push_back(std::move(srv));
-
-            rserver = rserver->NextSiblingElement(s_sRServer.c_str());
-        }
-    }
-
     if (shared_memory_off_)
     {
         // Desactivate transport by default
@@ -1017,69 +980,6 @@ void DiscoveryServerManager::loadClient(
     if (name != nullptr)
     {
         dpQOS.name() = name;
-    }
-
-    // server may be provided by prefix (takes precedence) or by list
-    const char* server = client->Attribute(s_sServer.c_str());
-    if (server != nullptr)
-    {
-        RemoteServerList_t::value_type srv;
-        GuidPrefix_t& prefix = srv.guidPrefix;
-
-        if (!(std::istringstream(server) >> prefix) &&
-                (prefix == c_GuidPrefix_Unknown))
-        {
-            LOG_ERROR("server attribute must provide a prefix"); // at least for now
-            return;
-        }
-
-        RemoteServerList_t& list = dpQOS.wire_protocol().builtin.discovery_config.m_DiscoveryServers;
-        list.clear(); // server elements take precedence over profile ones
-
-        // load the locator lists
-        serverLocator_map::mapped_type& lists = server_locators[srv.GetParticipant()];
-        srv.metatrafficMulticastLocatorList = lists.first;
-        srv.metatrafficUnicastLocatorList = lists.second;
-
-        list.push_back(std::move(srv));
-    }
-    else
-    {
-        // load the server list (if present) and update the builtin
-        tinyxml2::XMLElement* server_list = client->FirstChildElement(s_sSL.c_str());
-
-        if (server_list != nullptr)
-        {
-            RemoteServerList_t& list = dpQOS.wire_protocol().builtin.discovery_config.m_DiscoveryServers;
-            list.clear(); // server elements take precedence over profile ones
-
-            tinyxml2::XMLElement* rserver = server_list->FirstChildElement(s_sRServer.c_str());
-
-            while (rserver != nullptr)
-            {
-                RemoteServerList_t::value_type srv;
-                GuidPrefix_t& prefix = srv.guidPrefix;
-
-                // load the prefix
-                const char* cprefix = rserver->Attribute(DSxmlparser::PREFIX);
-
-                if (cprefix != nullptr && !(std::istringstream(cprefix) >> prefix)
-                        && (prefix == c_GuidPrefix_Unknown))
-                {
-                    LOG_ERROR("RServers must provide a prefix"); // at least for now
-                    return;
-                }
-
-                // load the locator lists
-                serverLocator_map::mapped_type& lists = server_locators[srv.GetParticipant()];
-                srv.metatrafficMulticastLocatorList = lists.first;
-                srv.metatrafficUnicastLocatorList = lists.second;
-
-                list.push_back(std::move(srv));
-
-                rserver = rserver->NextSiblingElement(s_sRServer.c_str());
-            }
-        }
     }
 
     // check for listening ports

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -1591,6 +1591,7 @@ void DiscoveryServerManager::on_participant_discovery(
 
     // if the callback origin was removed ignore
     GUID_t srcGuid = participant->guid();
+    std::string srcName = participant->get_qos().name().to_string();
     if ( nullptr == getParticipant(srcGuid))
     {
         LOG_INFO("Received onParticipantDiscovery callback from unknown participant: " << srcGuid);
@@ -1621,7 +1622,7 @@ void DiscoveryServerManager::on_participant_discovery(
     {
         case ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
         {
-            state.AddParticipant(srcGuid, partid, info.info.m_participantName.to_string(), callback_time,
+            state.AddParticipant(srcGuid, srcName, partid, info.info.m_participantName.to_string(), callback_time,
                     server);
             break;
         }
@@ -1646,6 +1647,7 @@ void DiscoveryServerManager::on_data_reader_discovery(
 
     // if the callback origin was removed ignore
     GUID_t srcGuid = participant->guid();
+    std::string srcName = participant->get_qos().name().to_string();
     if ( nullptr == getParticipant(srcGuid))
     {
         LOG_INFO("Received SubscriberDiscovery callback from unknown participant: " << srcGuid);
@@ -1701,7 +1703,7 @@ void DiscoveryServerManager::on_data_reader_discovery(
     switch (info.status)
     {
         case DS::DISCOVERED_READER:
-            state.AddDataReader(srcGuid, partid, subsid, info.info.typeName().to_string(),
+            state.AddDataReader(srcGuid, srcName, partid, subsid, info.info.typeName().to_string(),
                     info.info.topicName().to_string(), callback_time);
             break;
         case DS::REMOVED_READER:
@@ -1726,6 +1728,7 @@ void DiscoveryServerManager::on_data_writer_discovery(
 
     // if the callback origin was removed ignore
     GUID_t srcGuid = participant->guid();
+    std::string srcName = participant->get_qos().name().to_string();
     if ( nullptr == getParticipant(srcGuid))
     {
         LOG_INFO("Received PublisherDiscovery callback from unknown participant: " << srcGuid);
@@ -1783,6 +1786,7 @@ void DiscoveryServerManager::on_data_writer_discovery(
         case DS::DISCOVERED_WRITER:
 
             state.AddDataWriter(srcGuid,
+                    srcName,
                     partid,
                     pubsid,
                     info.info.typeName().to_string(),

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -1069,7 +1069,11 @@ void DiscoveryServerManager::loadClient(
             }
         }
 
-        pT->add_listener_port(static_cast<uint16_t>(listening_port));
+        if (pT->listening_ports.empty())
+        {
+            // if no ports are specified, we will use the default ones
+            pT->add_listener_port(static_cast<uint16_t>(listening_port));
+        }
 
         // set up WAN if specified
         if (!address.empty() && p4)

--- a/src/LateJoiner.cpp
+++ b/src/LateJoiner.cpp
@@ -28,7 +28,7 @@ void DelayedParticipantCreation::operator ()(
         DiscoveryServerManager& manager ) /*override*/
 {
 
-    DomainParticipant* p = DomainParticipantFactory::get_instance()->create_participant(0, qos, &manager);
+    DomainParticipant* p = DomainParticipantFactory::get_instance()->create_participant(42, qos, &manager);
 
     Publisher* publisher_ = p->create_publisher(PUBLISHER_QOS_DEFAULT);
     Subscriber* subscriber_ = p->create_subscriber(SUBSCRIBER_QOS_DEFAULT);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,6 +96,11 @@ list(APPEND TEST_LIST
 
         test_60_disconnection
         test_61_superclient_environment_variable
+
+        test_95_tcpv4_cli
+        test_96_tcpv6_cli
+        test_97_tcpv4_env_var
+        test_98_tcpv6_env_var
         test_99_tcp
     )
 
@@ -127,8 +132,7 @@ set(TEST_CASE_LIST)
 # Test that are leaky and may fail
 set(FAIL_TEST_CASES
     test_26_backup_restore
-    test_33_superclient_complex
-    test_99_tcp)
+    test_33_superclient_complex)
 
 # For each test case, create different executables for each configuration
 foreach(TEST IN LISTS TEST_LIST)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,8 +135,7 @@ set(TEST_CASE_LIST)
 
 # Test that are leaky and may fail
 set(FAIL_TEST_CASES
-    test_26_backup_restore
-    test_33_superclient_complex)
+    test_26_backup_restore)
 
 # For each test case, create different executables for each configuration
 foreach(TEST IN LISTS TEST_LIST)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,10 @@ list(APPEND TEST_LIST
         test_44_fast_discovery_server_tool_reconnect
         test_45_trivial_client_reconnect
 
+        test_46_guidless_discovery
+        test_47_guidless_server_double_ping
+        test_48_guidless_complex
+
         test_60_disconnection
         test_61_superclient_environment_variable
 

--- a/test/configuration/test_cases/test_01_trivial.xml
+++ b/test/configuration/test_cases/test_01_trivial.xml
@@ -26,16 +26,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -54,16 +50,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -82,9 +74,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>
@@ -106,3 +100,4 @@
 
      </profiles>
 </DS>
+

--- a/test/configuration/test_cases/test_02_single_server_medium.xml
+++ b/test/configuration/test_cases/test_02_single_server_medium.xml
@@ -129,7 +129,7 @@
     </clients>
 
     <snapshots file="./test_02_single_server_medium.snapshot~">
-        <snapshot time="6">test_02_single_server_medium_snapshot_1</snapshot>
+        <snapshot time="8">test_02_single_server_medium_snapshot_1</snapshot>
     </snapshots>
 
     <profiles>
@@ -140,16 +140,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -168,16 +164,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -196,16 +188,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -224,16 +212,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -252,16 +236,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -280,16 +260,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -308,16 +284,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -336,16 +308,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -364,16 +332,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -392,16 +356,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -420,16 +380,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -448,16 +404,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -476,16 +428,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -504,16 +452,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -532,16 +476,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -560,16 +500,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -588,16 +524,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -616,16 +548,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -644,16 +572,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -672,16 +596,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -700,16 +620,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -728,16 +644,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -756,16 +668,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -784,16 +692,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -812,16 +716,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -840,16 +740,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -868,16 +764,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -896,16 +788,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -924,16 +812,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -952,16 +836,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -980,16 +860,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1008,16 +884,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1036,16 +908,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1064,16 +932,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1092,16 +956,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1120,16 +980,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1148,16 +1004,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1176,16 +1028,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1204,16 +1052,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1232,16 +1076,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>02811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>02811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -1264,9 +1104,11 @@
                     </clientAnnouncementPeriod>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_03_single_server_large.xml
+++ b/test/configuration/test_cases/test_03_single_server_large.xml
@@ -784,17 +784,19 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                      <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>
                     <locator>
-                    <udpv4>
-                        <address>127.0.0.1</address>
-                        <port>03811</port>
-                    </udpv4>
+                        <udpv4>
+                            <address>127.0.0.1</address>
+                            <port>03811</port>
+                        </udpv4>
                     </locator>
                 </metatrafficUnicastLocatorList>
             </builtin>
@@ -815,16 +817,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -837,16 +835,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -863,16 +857,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -885,16 +875,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -911,16 +897,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -933,16 +915,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -959,16 +937,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -981,16 +955,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1007,16 +977,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1029,16 +995,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1055,16 +1017,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1077,16 +1035,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1103,16 +1057,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1125,16 +1075,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1151,16 +1097,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1173,16 +1115,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1199,16 +1137,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1221,16 +1155,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1247,16 +1177,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1269,16 +1195,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1295,16 +1217,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1317,16 +1235,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1343,16 +1257,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1365,16 +1275,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1391,16 +1297,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1413,16 +1315,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1439,16 +1337,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1461,16 +1355,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1487,16 +1377,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1509,16 +1395,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1535,16 +1417,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1557,16 +1435,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1583,16 +1457,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1605,16 +1475,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1631,16 +1497,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1653,16 +1515,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1679,16 +1537,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1701,16 +1555,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1727,16 +1577,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1749,16 +1595,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1775,16 +1617,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1797,16 +1635,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1823,16 +1657,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1845,16 +1675,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1871,16 +1697,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1893,16 +1715,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1919,16 +1737,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1941,16 +1755,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1967,16 +1777,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -1989,16 +1795,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2015,16 +1817,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2037,16 +1835,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2063,16 +1857,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2085,16 +1875,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2111,16 +1897,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2133,16 +1915,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2159,16 +1937,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2181,16 +1955,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2207,16 +1977,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2229,16 +1995,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2255,16 +2017,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2277,16 +2035,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2303,16 +2057,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2325,16 +2075,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2351,16 +2097,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2373,16 +2115,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2399,16 +2137,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2421,16 +2155,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2447,16 +2177,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2469,16 +2195,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2495,16 +2217,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2517,16 +2235,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2543,16 +2257,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2565,16 +2275,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2591,16 +2297,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2613,16 +2315,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2639,16 +2337,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2661,16 +2355,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2687,16 +2377,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2709,16 +2395,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2735,16 +2417,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2757,16 +2435,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2783,16 +2457,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2805,16 +2475,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2831,16 +2497,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2853,16 +2515,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2879,16 +2537,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2901,16 +2555,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2927,16 +2577,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2949,16 +2595,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2975,16 +2617,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -2997,16 +2635,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3023,16 +2657,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3045,16 +2675,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3071,16 +2697,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3093,16 +2715,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3119,16 +2737,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3141,16 +2755,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3167,16 +2777,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3189,16 +2795,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3215,16 +2817,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3237,16 +2835,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3263,16 +2857,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3285,16 +2875,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3311,16 +2897,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3333,16 +2915,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3359,16 +2937,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3381,16 +2955,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3407,16 +2977,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3429,16 +2995,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3455,16 +3017,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3477,16 +3035,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3503,16 +3057,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3525,16 +3075,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3551,16 +3097,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3573,16 +3115,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3599,16 +3137,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3621,16 +3155,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3647,16 +3177,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3669,16 +3195,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3695,16 +3217,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3717,16 +3235,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3743,16 +3257,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3765,16 +3275,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3791,16 +3297,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3813,16 +3315,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3839,16 +3337,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3861,16 +3355,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3887,16 +3377,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3909,16 +3395,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3935,16 +3417,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3957,16 +3435,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -3983,16 +3457,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4005,16 +3475,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4031,16 +3497,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4053,16 +3515,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4079,16 +3537,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4101,16 +3555,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4127,16 +3577,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4149,16 +3595,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4175,16 +3617,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4197,16 +3635,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4223,16 +3657,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4245,16 +3675,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4271,16 +3697,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4293,16 +3715,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4319,16 +3737,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4341,16 +3755,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4367,16 +3777,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4389,16 +3795,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4415,16 +3817,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4437,16 +3835,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4463,16 +3857,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4485,16 +3875,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4511,16 +3897,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4533,16 +3915,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4559,16 +3937,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4581,16 +3955,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4607,16 +3977,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4629,16 +3995,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4655,16 +4017,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4677,16 +4035,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4703,16 +4057,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4725,16 +4075,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4751,16 +4097,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4773,16 +4115,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4799,16 +4137,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4821,16 +4155,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4847,16 +4177,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4869,16 +4195,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4895,16 +4217,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4917,16 +4235,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4943,16 +4257,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4965,16 +4275,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -4991,16 +4297,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5013,16 +4315,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5039,16 +4337,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5061,16 +4355,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5087,16 +4377,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5109,16 +4395,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5135,16 +4417,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5157,16 +4435,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5183,16 +4457,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5205,16 +4475,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5231,16 +4497,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5253,16 +4515,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5279,16 +4537,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5301,16 +4555,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5327,16 +4577,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5349,16 +4595,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5375,16 +4617,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5397,16 +4635,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5423,16 +4657,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5445,16 +4675,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5471,16 +4697,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5493,16 +4715,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5519,16 +4737,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5541,16 +4755,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5567,16 +4777,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5589,16 +4795,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5615,16 +4817,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5637,16 +4835,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5663,16 +4857,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5685,16 +4875,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5711,16 +4897,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5733,16 +4915,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5759,16 +4937,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5781,16 +4955,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5807,16 +4977,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5829,16 +4995,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5855,16 +5017,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5877,16 +5035,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5903,16 +5057,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5925,16 +5075,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5951,16 +5097,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5973,16 +5115,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -5999,16 +5137,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6021,16 +5155,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6047,16 +5177,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6069,16 +5195,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6095,16 +5217,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6117,16 +5235,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6143,16 +5257,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6165,16 +5275,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6191,16 +5297,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6213,16 +5315,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6239,16 +5337,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6261,16 +5355,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6287,16 +5377,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6309,16 +5395,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6335,16 +5417,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6357,16 +5435,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6383,16 +5457,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6405,16 +5475,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6431,16 +5497,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6453,16 +5515,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6479,16 +5537,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6501,16 +5555,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6527,16 +5577,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6549,16 +5595,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6575,16 +5617,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6597,16 +5635,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6623,16 +5657,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6645,16 +5675,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6671,16 +5697,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6693,16 +5715,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6719,16 +5737,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6741,16 +5755,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6767,16 +5777,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6789,16 +5795,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6815,16 +5817,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6837,16 +5835,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6863,16 +5857,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6885,16 +5875,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6911,16 +5897,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>
@@ -6933,16 +5915,12 @@
                 <discovery_config>
                     <discoveryProtocol>CLIENT</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>03811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>03811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                 </discovery_config>
             </builtin>

--- a/test/configuration/test_cases/test_04_server_ping.xml
+++ b/test/configuration/test_cases/test_04_server_ping.xml
@@ -18,9 +18,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -41,22 +43,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_05_server_double_ping.xml
+++ b/test/configuration/test_cases/test_05_server_double_ping.xml
@@ -28,16 +28,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>05811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>05811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -56,16 +52,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>05812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>05812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -84,9 +76,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>
@@ -108,9 +102,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -131,32 +127,26 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>05811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>05812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>05811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>05812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_06_diamond_servers.xml
+++ b/test/configuration/test_cases/test_06_diamond_servers.xml
@@ -35,16 +35,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -63,16 +59,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -91,16 +83,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -119,16 +107,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.34">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06814</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06814</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -147,9 +131,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -170,22 +156,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -206,22 +190,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -242,32 +224,26 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_07_server_endpoints_two_servers.xml
+++ b/test/configuration/test_cases/test_07_server_endpoints_two_servers.xml
@@ -14,33 +14,6 @@
     </snapshots>
 
     <profiles>
-        <participant profile_name="UDP client" >
-        <rtps>
-            <builtin>
-                <discovery_config>
-                    <discoveryProtocol>CLIENT</discoveryProtocol>
-                    <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>07811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
-                    </discoveryServersList>
-                    <initialAnnouncements>
-                        <count>0</count>
-                    </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                    <leaseDuration>DURATION_INFINITY</leaseDuration>
-                </discovery_config>
-            </builtin>
-        </rtps>
-        </participant>
-
         <participant profile_name="UDP_server1">
             <rtps>
                 <prefix>44.49.53.43.53.45.52.56.45.52.5F.31</prefix>
@@ -48,9 +21,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -71,22 +46,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>07811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>07811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_08_server_endpoints_four_clients.xml
+++ b/test/configuration/test_cases/test_08_server_endpoints_four_clients.xml
@@ -36,16 +36,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>08811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>08811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -64,16 +60,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>08811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>08811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -92,16 +84,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>08811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>08811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -120,16 +108,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>08811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>08811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -148,9 +132,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_09_servers_serial.xml
+++ b/test/configuration/test_cases/test_09_servers_serial.xml
@@ -24,16 +24,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>09811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>09811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -52,9 +48,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -75,22 +73,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>09811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>09811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -111,22 +107,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>09812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>09812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_10_server_redundancy.xml
+++ b/test/configuration/test_cases/test_10_server_redundancy.xml
@@ -24,36 +24,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>10811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>10812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>10813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>10811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>10812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>10813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -72,9 +60,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -96,9 +86,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -120,9 +112,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_11_remote_servers.xml
+++ b/test/configuration/test_cases/test_11_remote_servers.xml
@@ -21,9 +21,9 @@
     </clients>
 
     <snapshots file="test_11_remote_servers.snapshot~">
-        <!-- Server3 should not know Server1 as it has no endpoints. -->
+        <!-- Server3 should know Server1 because servers connect in mesh topology -->
         <snapshot time="3">test_11_remote_servers_snapshot_1</snapshot>
-        <!-- Server3 match Server1 as is has an publisher now -->
+        <!-- Server3 should also show the publisherof server 1 -->
         <snapshot time="6">test_11_remote_servers_snapshot_2</snapshot>
     </snapshots>
 
@@ -35,184 +35,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                        </discoveryServersList>
-                        <initialAnnouncements>
-                            <count>0</count>
-                        </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
-                    </discovery_config>
-                </builtin>
-            </rtps>
-        </participant>
-
-        <participant profile_name="UDP_client2_server1" >
-            <rtps>
-                <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
-                <builtin>
-                    <discovery_config>
-                        <discoveryProtocol>CLIENT</discoveryProtocol>
-                        <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                        </discoveryServersList>
-                        <initialAnnouncements>
-                            <count>0</count>
-                        </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
-                    </discovery_config>
-                </builtin>
-            </rtps>
-        </participant>
-
-        <participant profile_name="UDP_client1_server2" >
-            <rtps>
-                <prefix>63.6c.69.65.6e.74.31.5f.73.32.5f.5f</prefix>
-                <builtin>
-                    <discovery_config>
-                        <discoveryProtocol>CLIENT</discoveryProtocol>
-                        <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                        </discoveryServersList>
-                        <initialAnnouncements>
-                            <count>0</count>
-                        </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
-                    </discovery_config>
-                </builtin>
-            </rtps>
-        </participant>
-
-        <participant profile_name="UDP_client2_server2" >
-            <rtps>
-                <prefix>63.6c.69.65.6e.74.32.5f.73.32.5f.5f</prefix>
-                <builtin>
-                    <discovery_config>
-                        <discoveryProtocol>CLIENT</discoveryProtocol>
-                        <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                        </discoveryServersList>
-                        <initialAnnouncements>
-                            <count>0</count>
-                        </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
-                    </discovery_config>
-                </builtin>
-            </rtps>
-        </participant>
-
-        <participant profile_name="UDP_client1_server3" >
-            <rtps>
-                <prefix>63.6c.69.65.6e.74.31.5f.73.33.5f.5f</prefix>
-                <builtin>
-                    <discovery_config>
-                        <discoveryProtocol>CLIENT</discoveryProtocol>
-                        <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                        </discoveryServersList>
-                        <initialAnnouncements>
-                            <count>0</count>
-                        </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
-                    </discovery_config>
-                </builtin>
-            </rtps>
-        </participant>
-
-        <participant profile_name="UDP_client2_server3" >
-            <rtps>
-                <prefix>63.6c.69.65.6e.74.32.5f.73.33.5f.5f</prefix>
-                <builtin>
-                    <discovery_config>
-                        <discoveryProtocol>CLIENT</discoveryProtocol>
-                        <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                        </discoveryServersList>
-                        <initialAnnouncements>
-                            <count>0</count>
-                        </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
-                    </discovery_config>
-                </builtin>
-            </rtps>
-        </participant>
-
-        <participant profile_name="UDP_client1_server5" >
-            <rtps>
-                <prefix>63.6c.69.65.6e.74.31.5f.73.35.5f.5f</prefix>
-                <builtin>
-                    <discovery_config>
-                        <discoveryProtocol>CLIENT</discoveryProtocol>
-                        <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.35">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11815</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -231,9 +59,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -254,22 +84,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -290,22 +118,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -322,16 +148,6 @@
 
         <topic profile_name="topic1">
             <name>topic_1</name>
-            <dataType>HelloWorld</dataType>
-        </topic>
-
-        <topic profile_name="topic2">
-            <name>topic_2</name>
-            <dataType>HelloWorld</dataType>
-        </topic>
-
-        <topic profile_name="topic3">
-            <name>topic_3</name>
             <dataType>HelloWorld</dataType>
         </topic>
 

--- a/test/configuration/test_cases/test_12_virtual_topics.xml
+++ b/test/configuration/test_cases/test_12_virtual_topics.xml
@@ -7,55 +7,15 @@
         </server>
         <server name="server2" prefix="44.49.53.43.53.45.52.56.45.52.5f.32" profile_name="UDP_server2">
             <subscriber topic="topic1"/>
-            <ListeningPorts>
-                <metatrafficUnicastLocatorList>
-                    <locator>
-                        <udpv4>
-                            <address>127.0.0.1</address>
-                            <port>12812</port>
-                        </udpv4>
-                    </locator>
-                </metatrafficUnicastLocatorList>
-            </ListeningPorts>
         </server>
         <server name="server3" prefix="44.49.53.43.53.45.52.56.45.52.5f.33" profile_name="UDP_server3">
             <subscriber topic="topic1"/>
             <publisher topic="topic3"/>
-            <ListeningPorts>
-                <metatrafficUnicastLocatorList>
-                    <locator>
-                        <udpv4>
-                            <address>127.0.0.1</address>
-                            <port>12813</port>
-                        </udpv4>
-                    </locator>
-                </metatrafficUnicastLocatorList>
-            </ListeningPorts>
         </server>
         <server name="server4" prefix="44.49.53.43.53.45.52.56.45.52.5f.34" profile_name="UDP_server4">
             <subscriber topic="topic3"/>
-            <ListeningPorts>
-                <metatrafficUnicastLocatorList>
-                    <locator>
-                        <udpv4>
-                            <address>127.0.0.1</address>
-                            <port>12814</port>
-                        </udpv4>
-                    </locator>
-                </metatrafficUnicastLocatorList>
-            </ListeningPorts>
         </server>
         <server name="server5" prefix="44.49.53.43.53.45.52.56.45.52.5f.35" profile_name="UDP_server5">
-            <ListeningPorts>
-                <metatrafficUnicastLocatorList>
-                    <locator>
-                        <udpv4>
-                            <address>127.0.0.1</address>
-                            <port>12815</port>
-                        </udpv4>
-                    </locator>
-                </metatrafficUnicastLocatorList>
-            </ListeningPorts>
         </server>
     </servers>
 
@@ -95,16 +55,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -123,16 +79,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -151,16 +103,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -179,16 +127,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -207,16 +151,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -235,16 +175,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -263,16 +199,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.35">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12815</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12815</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -291,9 +223,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -314,22 +248,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -350,32 +282,26 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.34">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12814</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12814</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -397,9 +323,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -420,22 +348,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>12812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>12812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_12_virtual_topics.xml
+++ b/test/configuration/test_cases/test_12_virtual_topics.xml
@@ -17,9 +17,6 @@
                     </locator>
                 </metatrafficUnicastLocatorList>
             </ListeningPorts>
-            <ServersList>
-                <RServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31" />
-            </ServersList>
         </server>
         <server name="server3" prefix="44.49.53.43.53.45.52.56.45.52.5f.33" profile_name="UDP_server3">
             <subscriber topic="topic1"/>
@@ -34,10 +31,6 @@
                     </locator>
                 </metatrafficUnicastLocatorList>
             </ListeningPorts>
-            <ServersList>
-                <RServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32" />
-                <RServer prefix="44.49.53.43.53.45.52.56.45.52.5F.34" />
-            </ServersList>
         </server>
         <server name="server4" prefix="44.49.53.43.53.45.52.56.45.52.5f.34" profile_name="UDP_server4">
             <subscriber topic="topic3"/>
@@ -63,9 +56,6 @@
                     </locator>
                 </metatrafficUnicastLocatorList>
             </ListeningPorts>
-            <ServersList>
-                <RServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32" />
-            </ServersList>
         </server>
     </servers>
 

--- a/test/configuration/test_cases/test_13_disposals_single_server.xml
+++ b/test/configuration/test_cases/test_13_disposals_single_server.xml
@@ -129,7 +129,7 @@
         <snapshot time="20">test_13_disposals_single_server_8.[P1,P2]_-_9.[S1,S2]</snapshot>
         <snapshot time="23">test_13_disposals_single_server_8.P2_-_9.S2</snapshot>
 
-        <snapshot time="26">test_13_disposals_single_server_a.P1_-_b.S1</snapshot>
+        <snapshot time="27">test_13_disposals_single_server_a.P1_-_b.S1</snapshot>
         <snapshot time="30">test_13_disposals_single_server_a_-_b</snapshot>
 
         <snapshot time="34">test_13_disposals_single_server_c.S1_-_d.P1</snapshot>
@@ -148,16 +148,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -176,16 +172,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -204,16 +196,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -232,16 +220,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -260,16 +244,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -288,16 +268,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -316,16 +292,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -344,16 +316,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -372,16 +340,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -400,16 +364,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -428,16 +388,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -456,16 +412,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -484,16 +436,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -512,16 +460,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>11811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>11811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -540,9 +484,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_14_disposals_remote_servers.xml
+++ b/test/configuration/test_cases/test_14_disposals_remote_servers.xml
@@ -25,23 +25,23 @@
 
         <!-- Starting point -->
         <snapshot time="3">test_14_disposals_remote_servers_snapshot_1</snapshot>
-        <!-- Remove subscriber1 from server3 -->
+        <!-- 4 - Remove subscriber1 from server3 -->
         <snapshot time="6">test_14_disposals_remote_servers_snapshot_2</snapshot>
         <!--
-            Remove subscriber1 from server2
-            Create subscriber2 in server3
+            7 - Remove subscriber1 from server2
+            7 - Create subscriber2 in server3
          -->
         <snapshot time="9">test_14_disposals_remote_servers_snapshot_3</snapshot>
-        <!-- Remove publisher 1 from client1_server1 -->
+        <!-- 10 - Remove publisher 1 from client1_server1 -->
         <snapshot time="13">test_14_disposals_remote_servers_snapshot_4</snapshot>
-        <!-- Remove client1_server1 -->
+        <!-- 14 - Remove client1_server1 -->
         <snapshot time="17">test_14_disposals_remote_servers_snapshot_5</snapshot>
         <!--
-            Create client2_server1
-            Create a publisher in client2_server1
+            18 - Create client2_server1
+            18 - Create a publisher in client2_server1
          -->
         <snapshot time="21">test_14_disposals_remote_servers_snapshot_6</snapshot>
-        <!-- Remove server3 -->
+        <!-- 22 - Remove server3 -->
         <snapshot time="25">test_14_disposals_remote_servers_snapshot_7</snapshot>
 
     </snapshots>
@@ -54,16 +54,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>14811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>14811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -77,16 +73,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>14811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>14811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -118,16 +110,12 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>14811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>14811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                     </discovery_config>
@@ -149,19 +137,17 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>14812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>14812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_15_disposals_client_servers.xml
+++ b/test/configuration/test_cases/test_15_disposals_client_servers.xml
@@ -43,16 +43,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>15811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>15811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -66,16 +62,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>15813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>15813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -89,9 +81,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -112,22 +106,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>15811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>15811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -148,22 +140,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>15811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>15811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_16_lease_duration_single_client.xml
+++ b/test/configuration/test_cases/test_16_lease_duration_single_client.xml
@@ -40,16 +40,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>16811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>16811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <leaseDuration>
                             <sec>5</sec>
@@ -69,16 +65,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>16811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>16811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <leaseDuration>
                             <sec>5</sec>

--- a/test/configuration/test_cases/test_16_lease_duration_single_client_1.xml
+++ b/test/configuration/test_cases/test_16_lease_duration_single_client_1.xml
@@ -19,16 +19,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>16811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>16811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <leaseDuration>
                             <sec>3</sec>

--- a/test/configuration/test_cases/test_17_lease_duration_remove_client_server.xml
+++ b/test/configuration/test_cases/test_17_lease_duration_remove_client_server.xml
@@ -39,16 +39,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>17811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>17811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <leaseDuration>
                             <sec>5</sec>
@@ -68,16 +64,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>17811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>17811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <leaseDuration>
                             <sec>5</sec>

--- a/test/configuration/test_cases/test_17_lease_duration_remove_client_server_1.xml
+++ b/test/configuration/test_cases/test_17_lease_duration_remove_client_server_1.xml
@@ -7,6 +7,7 @@
         </server>
     </servers>
 
+    <!-- Used only to keep the server alive, but not for validation -->
     <snapshots file="./test_17_lease_duration_remove_client_server_1.snapshot~">
         <snapshot time="20">test_17_lease_duration_remove_client_server_1_snapshot_1</snapshot>
     </snapshots>
@@ -19,20 +20,16 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>17811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>17811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                         <leaseDuration>
                             <sec>3</sec>

--- a/test/configuration/test_cases/test_18_disposals_remote_servers_multiprocess.xml
+++ b/test/configuration/test_cases/test_18_disposals_remote_servers_multiprocess.xml
@@ -26,16 +26,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>18811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>18811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
@@ -50,7 +46,9 @@
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_18_disposals_remote_servers_multiprocess_1.xml
+++ b/test/configuration/test_cases/test_18_disposals_remote_servers_multiprocess_1.xml
@@ -16,19 +16,17 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>18811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>18811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_18_disposals_remote_servers_multiprocess_2.xml
+++ b/test/configuration/test_cases/test_18_disposals_remote_servers_multiprocess_2.xml
@@ -19,19 +19,17 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>18812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>18812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_19_disposals_break_builtin_connections.xml
+++ b/test/configuration/test_cases/test_19_disposals_break_builtin_connections.xml
@@ -26,7 +26,7 @@
         <snapshot time="3">test_19_disposals_break_builtin_connections_snapshot_1</snapshot>
         <!-- Remove server2 which is a client of server1 -->
         <snapshot time="6">test_19_disposals_break_builtin_connections_snapshot_2</snapshot>
-        <!-- Create client2_server1. Server3 should never match with this new client. -->
+        <!-- Create client2_server1. Server3 should match with this new client. -->
         <snapshot time="9">test_19_disposals_break_builtin_connections_snapshot_3</snapshot>
 
     </snapshots>
@@ -39,16 +39,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>19811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>19811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -62,16 +58,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>19811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>19811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -85,7 +77,7 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -106,16 +98,12 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>19811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>19811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                     </discovery_config>
@@ -137,16 +125,12 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>19812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>19812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                     </discovery_config>

--- a/test/configuration/test_cases/test_20_break_builtin_connections.xml
+++ b/test/configuration/test_cases/test_20_break_builtin_connections.xml
@@ -23,7 +23,7 @@
         <snapshot time="3">test_20_break_builtin_connections_snapshot_1</snapshot>
         <!-- Remove server2 which is a client of server1 -->
         <snapshot time="9">test_20_break_builtin_connections_snapshot_2</snapshot>
-        <!-- Create client2_server1. Server3 should never match with this new client. -->
+        <!-- Create client2_server1. Server3 should match with this new client. -->
         <snapshot time="13">test_20_break_builtin_connections_snapshot_3</snapshot>
 
     </snapshots>
@@ -36,16 +36,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>20811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>20811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <leaseDuration>
                             <sec>5</sec>
@@ -65,16 +61,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>20811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>20811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <leaseDuration>
                             <sec>5</sec>
@@ -94,7 +86,7 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                         <leaseDuration>
                             <sec>5</sec>
@@ -121,20 +113,16 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>20811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>20811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                         <leaseDuration>
                             <sec>5</sec>
@@ -161,20 +149,16 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>20812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>20812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                         <leaseDuration>
                             <sec>5</sec>

--- a/test/configuration/test_cases/test_20_break_builtin_connections_1.xml
+++ b/test/configuration/test_cases/test_20_break_builtin_connections_1.xml
@@ -8,7 +8,7 @@
     </servers>
 
     <snapshots file="./test_20_break_builtin_connections_1.snapshot~">
-        <!-- This server will be kill 4 seconds after initialization -->
+        <!-- This server will be killed 4 seconds after initialization -->
         <snapshot time="20">test_20_break_builtin_connections_1_snapshot_1</snapshot>
     </snapshots>
 
@@ -20,20 +20,16 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>20811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>20811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                         <leaseDuration>
                             <sec>5</sec>

--- a/test/configuration/test_cases/test_21_disposals_remote_server_trivial.xml
+++ b/test/configuration/test_cases/test_21_disposals_remote_server_trivial.xml
@@ -28,16 +28,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>21811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>21811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -51,16 +47,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>21811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>21811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -74,7 +66,7 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -95,20 +87,16 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>21811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>21811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -129,20 +117,16 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>21812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>21812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_22_environment_variable_setup.xml
+++ b/test/configuration/test_cases/test_22_environment_variable_setup.xml
@@ -16,7 +16,7 @@
     </simples>
 
     <snapshots file="./test_22_environment_variable_setup.snapshot~">
-        <snapshot time="2">test_22_environment_variable_setup_snapshot_1</snapshot>
+        <snapshot time="5">test_22_environment_variable_setup_snapshot_1</snapshot>
     </snapshots>
 
     <profiles>

--- a/test/configuration/test_cases/test_23_fast_discovery_server_tool.xml
+++ b/test/configuration/test_cases/test_23_fast_discovery_server_tool.xml
@@ -30,16 +30,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>23811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>23811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -53,16 +49,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>23811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>23811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -76,16 +68,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>23811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>23811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -99,16 +87,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>23811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>23811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>

--- a/test/configuration/test_cases/test_24_backup_1.xml
+++ b/test/configuration/test_cases/test_24_backup_1.xml
@@ -37,16 +37,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>24811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>24811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -60,16 +56,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>24811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>24811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>

--- a/test/configuration/test_cases/test_25_backup_compatibility.xml
+++ b/test/configuration/test_cases/test_25_backup_compatibility.xml
@@ -36,16 +36,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>25811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>25811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -59,16 +55,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>25812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>25812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -82,16 +74,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>25813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>25813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -123,16 +111,12 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>25811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>25811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>BACKUP</discoveryProtocol>
                     </discovery_config>
@@ -154,16 +138,12 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>25812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>25812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                     </discovery_config>

--- a/test/configuration/test_cases/test_26_backup_restore.xml
+++ b/test/configuration/test_cases/test_26_backup_restore.xml
@@ -28,16 +28,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>26811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>26811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>

--- a/test/configuration/test_cases/test_26_backup_restore_1.xml
+++ b/test/configuration/test_cases/test_26_backup_restore_1.xml
@@ -23,16 +23,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>26811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>26811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>

--- a/test/configuration/test_cases/test_27_slow_arise.xml
+++ b/test/configuration/test_cases/test_27_slow_arise.xml
@@ -37,36 +37,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -85,36 +73,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -133,36 +109,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -181,36 +145,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -229,9 +181,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -253,9 +207,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -277,9 +233,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_28_slow_arise_interconnection.xml
+++ b/test/configuration/test_cases/test_28_slow_arise_interconnection.xml
@@ -37,36 +37,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -85,36 +73,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -133,36 +109,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -181,36 +145,24 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -229,9 +181,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -252,22 +206,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -288,22 +240,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>06812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>06812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_29_server_ping_late_joiner.xml
+++ b/test/configuration/test_cases/test_29_server_ping_late_joiner.xml
@@ -18,7 +18,7 @@
 
     <snapshots file="./test_29_server_ping_late_joiner.snapshot~">
         <snapshot time="3">3.4 knows each other</snapshot>
-        <snapshot time="7">1.2 knows each other, 2.3 knows each other</snapshot>
+        <snapshot time="7">all know each other</snapshot>
     </snapshots>
 
     <profiles>
@@ -29,9 +29,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -52,22 +54,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -88,22 +88,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -124,22 +122,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_30_connect_locally_with_remote_entity.xml
+++ b/test/configuration/test_cases/test_30_connect_locally_with_remote_entity.xml
@@ -2,8 +2,12 @@
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
     <!--
-        In this test the case is that a Server will known a Client that must ping it before
-        it actually pings the server (by other server connection).
+        In this test the client is configured to not use initial announcements and have infinite lease period
+        announcement. This will result in no communication with the server until the client event is triggered.
+        In the first trigger, the client will announce its PDP. In the second trigger, the client will announce
+        its EDP. This will result in S1 knowing C1's participant at second 5 and its endpoints at second 10.
+        S2 will not know C1 until second 10, because S1 does not resend C1's PDP until it matches its endpoints
+        and the dirty topics are processed.
     -->
 
     <servers>
@@ -18,7 +22,7 @@
     </clients>
 
     <snapshots file="./test_30_connect_locally_with_remote_entity.snapshot~">
-        <snapshot time="9">S2 knows C1 but C1 does not know S2</snapshot>
+        <snapshot time="9">S1 knows C1 PDP. S2 only knows S1</snapshot>
         <snapshot time="12">All knows each other</snapshot>
     </snapshots>
 
@@ -30,26 +34,18 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -71,9 +67,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -94,22 +92,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_31_matched_servers_not_share_info.xml
+++ b/test/configuration/test_cases/test_31_matched_servers_not_share_info.xml
@@ -2,7 +2,8 @@
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
     <!--
-        This case tests that two servers matched because of their endpoints do not share discovery info
+        This case tests that two servers that matched because of their endpoints or because of an
+        external server share discovery info
     -->
 
     <servers>
@@ -28,7 +29,7 @@
 
     <snapshots file="./test_31_matched_servers_not_share_info.snapshot~">
         <snapshot time="3">all servers know each other and client1</snapshot>
-        <snapshot time="7">server1 not know remote client2</snapshot>
+        <snapshot time="7">server1 knows remote client2</snapshot>
     </snapshots>
 
     <profiles>
@@ -39,16 +40,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -67,16 +64,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -95,9 +88,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -118,32 +113,26 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>04813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>04813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -165,9 +154,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_32_superclient_trivial.xml
+++ b/test/configuration/test_cases/test_32_superclient_trivial.xml
@@ -39,16 +39,12 @@
                     <discovery_config>
                         <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -67,16 +63,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -95,16 +87,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -123,16 +111,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -151,16 +135,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -179,16 +159,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -207,9 +183,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_32_superclient_trivial.xml
+++ b/test/configuration/test_cases/test_32_superclient_trivial.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- It checks the SUPER_CLIENT participant type knows every other participant with endpoints
-        and it does not know participants with endpoints -->
+    <!-- It checks the SUPER_CLIENT participant type knows every other participant with endpoints,
+        it does not match directly with servers and it does not know participants without endpoints.
+        Note that S2 will not discovery C5 because it does not have endpoints, so there cannot be
+        match between the virtual writer because there are no readers. -->
 
     <servers>
-        <server name="server" profile_name="UDP server" />
+        <server name="server1" profile_name="UDP server1" />
+        <server name="server2" profile_name="UDP server2" />
     </servers>
 
     <clients>
@@ -28,7 +31,7 @@
     </clients>
 
     <snapshots file="./test_32_superclient_trivial.snapshot~">
-        <snapshot time="2">test_32_superclient_trivial</snapshot>
+        <snapshot time="3">test_32_superclient_trivial</snapshot>
     </snapshots>
 
     <profiles>
@@ -176,7 +179,7 @@
             </rtps>
         </participant>
 
-        <participant profile_name="UDP server">
+        <participant profile_name="UDP server1">
         <rtps>
             <prefix>44.49.53.43.53.45.52.56.45.52.5F.31</prefix>
             <builtin>
@@ -195,6 +198,40 @@
                         <udpv4>
                             <address>127.0.0.1</address>
                             <port>01811</port>
+                        </udpv4>
+                    </locator>
+                </metatrafficUnicastLocatorList>
+            </builtin>
+        </rtps>
+        </participant>
+
+        <participant profile_name="UDP server2">
+        <rtps>
+            <prefix>44.49.53.43.53.45.52.56.45.52.5F.32</prefix>
+            <builtin>
+                <discovery_config>
+                    <discoveryProtocol>SERVER</discoveryProtocol>
+                    <discoveryServersList>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>01811</port>
+                            </udpv4>
+                        </locator>
+                    </discoveryServersList>
+                    <initialAnnouncements>
+                        <count>5</count>
+                    </initialAnnouncements>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
+                    <leaseDuration>DURATION_INFINITY</leaseDuration>
+                </discovery_config>
+                <metatrafficUnicastLocatorList>
+                    <locator>
+                        <udpv4>
+                            <address>127.0.0.1</address>
+                            <port>01812</port>
                         </udpv4>
                     </locator>
                 </metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_33_superclient_complex.xml
+++ b/test/configuration/test_cases/test_33_superclient_complex.xml
@@ -75,16 +75,12 @@
                     <discovery_config>
                         <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -103,26 +99,18 @@
                     <discovery_config>
                         <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -141,16 +129,12 @@
                     <discovery_config>
                         <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -169,16 +153,12 @@
                     <discovery_config>
                         <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -198,16 +178,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -226,16 +202,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -254,16 +226,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -282,26 +250,18 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -320,22 +280,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -356,22 +314,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -392,22 +348,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>BACKUP</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -428,22 +382,20 @@
                 <builtin>
                     <discovery_config>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>33813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>33813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_33_superclient_complex.xml
+++ b/test/configuration/test_cases/test_33_superclient_complex.xml
@@ -85,7 +85,9 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
@@ -115,7 +117,9 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
@@ -139,7 +143,9 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
@@ -163,7 +169,9 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
@@ -188,7 +196,9 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
@@ -212,7 +222,9 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
@@ -236,7 +248,9 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
@@ -266,7 +280,9 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
@@ -355,7 +371,7 @@
                                 </udpv4>
                             </locator>
                         </discoveryServersList>
-                        <discoveryProtocol>BACKUP</discoveryProtocol>
+                        <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
                             <count>5</count>
                         </initialAnnouncements>

--- a/test/configuration/test_cases/test_34_connect_locally_with_remote_server.xml
+++ b/test/configuration/test_cases/test_34_connect_locally_with_remote_server.xml
@@ -19,8 +19,12 @@
         </client>
     </clients>
 
+    <!-- S2 will send known servers' PDP to new servers and new servers' PDP to known servers.
+         Hence, S3 and S1 will know each other, and S3 will know S1 endpoint, as S1'
+         endpoints will be announced by S2. Note that the clientAnnouncementPeriod of S1
+         has not been triggered when the snapshot is taken -->
     <snapshots file="./test_31_matched_servers_not_share_info.snapshot~">
-        <snapshot time="8">s3 knows s1 (remotely) but s1 does not know s3</snapshot>
+        <snapshot time="8">s3 knows s1 and s1 knows s3</snapshot>
         <snapshot time="13">s1 knows s3 and its client</snapshot>
     </snapshots>
 
@@ -32,16 +36,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>34813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>34813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -60,31 +60,25 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>34812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.33">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>34813</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>34812</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>34813</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>1</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                         <clientAnnouncementPeriod>
                             <sec>5</sec>
@@ -109,9 +103,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -133,21 +129,19 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>34812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>34812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_35_fds_two_connected_servers_with_clients.xml
+++ b/test/configuration/test_cases/test_35_fds_two_connected_servers_with_clients.xml
@@ -34,16 +34,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>35811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>35811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -62,16 +58,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.01.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>35812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>35812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>

--- a/test/configuration/test_cases/test_36_dns_environment_variable_setup.xml
+++ b/test/configuration/test_cases/test_36_dns_environment_variable_setup.xml
@@ -3,12 +3,8 @@
 
     <!--
         This test merely assesses that the simple participants become full-fledged clients by using
-        the ROS_DISCOVERY_SERVER. They must locate the server defined as the base default one.
+        the ROS_DISCOVERY_SERVER with dns. They must locate the server defined as the base default one.
     -->
-
-    <servers>
-        <server name="server1" profile_name="UDP_server" />
-    </servers>
 
     <simples>
         <simple name="client1" profile_name="UDP_client1"/>
@@ -43,32 +39,6 @@
         <participant profile_name="UDP_client4" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.34.5f.73.31.5f.5f</prefix>
-            </rtps>
-        </participant>
-
-        <participant profile_name="UDP_server">
-            <rtps>
-                <prefix>44.53.00.5f.45.50.52.4f.53.49.4d.41</prefix>
-                <builtin>
-                    <discovery_config>
-                        <clientAnnouncementPeriod>
-                            <sec>0</sec>
-                            <nanosec>20000000</nanosec>
-                        </clientAnnouncementPeriod>
-                        <discoveryProtocol>SERVER</discoveryProtocol>
-                        <initialAnnouncements>
-                            <count>0</count>
-                        </initialAnnouncements>
-                    </discovery_config>
-                    <metatrafficUnicastLocatorList>
-                        <locator>
-                            <udpv4>
-                                <address>localhost</address>
-                                <port>36811</port>
-                            </udpv4>
-                        </locator>
-                    </metatrafficUnicastLocatorList>
-                </builtin>
             </rtps>
         </participant>
 

--- a/test/configuration/test_cases/test_37_dns_fast_discovery_server_tool.xml
+++ b/test/configuration/test_cases/test_37_dns_fast_discovery_server_tool.xml
@@ -30,16 +30,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>localhost</address>
-                                            <port>37811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>localhost</address>
+                                    <port>37811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -53,16 +49,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>localhost</address>
-                                            <port>37811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>localhost</address>
+                                    <port>37811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -76,16 +68,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>localhost</address>
-                                            <port>37811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>localhost</address>
+                                    <port>37811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -99,16 +87,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>localhost</address>
-                                            <port>37811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>localhost</address>
+                                    <port>37811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>

--- a/test/configuration/test_cases/test_38_self_connection.xml
+++ b/test/configuration/test_cases/test_38_self_connection.xml
@@ -26,16 +26,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>38811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>38811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -54,16 +50,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>38811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>38811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -81,22 +73,20 @@
             <builtin>
                 <discovery_config>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>38811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>38811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_39_trivial_reconnect_A.xml
+++ b/test/configuration/test_cases/test_39_trivial_reconnect_A.xml
@@ -19,9 +19,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_39_trivial_reconnect_B.xml
+++ b/test/configuration/test_cases/test_39_trivial_reconnect_B.xml
@@ -19,21 +19,19 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>39811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>39811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_40_trivial_server_reconnect_A.xml
+++ b/test/configuration/test_cases/test_40_trivial_server_reconnect_A.xml
@@ -19,21 +19,19 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>40812</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>40812</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_40_trivial_server_reconnect_B.xml
+++ b/test/configuration/test_cases/test_40_trivial_server_reconnect_B.xml
@@ -19,9 +19,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_41_reconnect_with_clients_A.xml
+++ b/test/configuration/test_cases/test_41_reconnect_with_clients_A.xml
@@ -12,9 +12,9 @@
     </clients>
 
     <snapshots file="./test_41_reconnect_with_clients_A.snapshot~">
-        <snapshot time="2">Knows server B, client A and client B</snapshot>
-        <snapshot time="12">Do not know server B</snapshot>
-        <snapshot time="18">Knows server B, client A and client B</snapshot>
+        <snapshot time="5">Knows server B, client A and client B</snapshot>
+        <snapshot time="15">Do not know server B</snapshot>
+        <snapshot time="21">Knows server B, client A and client B</snapshot>
     </snapshots>
 
     <profiles>
@@ -26,16 +26,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>41811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>41811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>

--- a/test/configuration/test_cases/test_41_reconnect_with_clients_B.xml
+++ b/test/configuration/test_cases/test_41_reconnect_with_clients_B.xml
@@ -12,8 +12,8 @@
     </clients>
 
     <snapshots file="./test_41_reconnect_with_clients_B.snapshot~">
-        <snapshot time="4">Knows server A, client A and client B</snapshot>
-        <snapshot time="8">Do not know server A</snapshot>
+        <snapshot time="5">Knows server A, client A and client B</snapshot>
+        <snapshot time="10">Do not know server A</snapshot>
     </snapshots>
 
     <profiles>
@@ -25,16 +25,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>41812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>41812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -53,19 +49,15 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>41811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>41811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
                     <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>

--- a/test/configuration/test_cases/test_42_server_reconnect_with_clients_A.xml
+++ b/test/configuration/test_cases/test_42_server_reconnect_with_clients_A.xml
@@ -12,9 +12,9 @@
     </clients>
 
     <snapshots file="./test_42_server_reconnect_with_clients_A.snapshot~">
-        <snapshot time="2">Knows server B, client A and client B</snapshot>
-        <snapshot time="12">Do not know server B</snapshot>
-        <snapshot time="18">Knows server B, client A and client B</snapshot>
+        <snapshot time="5">Knows server B, client A and client B</snapshot>
+        <snapshot time="15">Do not know server B</snapshot>
+        <snapshot time="21">Knows server B, client A and client B</snapshot>
     </snapshots>
 
     <profiles>
@@ -26,16 +26,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>42811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>42811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -54,21 +50,19 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>42812</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>42812</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_42_server_reconnect_with_clients_B.xml
+++ b/test/configuration/test_cases/test_42_server_reconnect_with_clients_B.xml
@@ -12,8 +12,8 @@
     </clients>
 
     <snapshots file="./test_42_server_reconnect_with_clients_B.snapshot~">
-        <snapshot time="4">Knows server A, client A and client B</snapshot>
-        <snapshot time="8">Do not know server A</snapshot>
+        <snapshot time="5">Knows server A, client A and client B</snapshot>
+        <snapshot time="10">Do not know server A</snapshot>
     </snapshots>
 
     <profiles>
@@ -25,16 +25,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>42812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>42812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -53,9 +49,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_43_complex_reconnect_A1.xml
+++ b/test/configuration/test_cases/test_43_complex_reconnect_A1.xml
@@ -25,16 +25,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>43811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>43811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -53,9 +49,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_43_complex_reconnect_A2.xml
+++ b/test/configuration/test_cases/test_43_complex_reconnect_A2.xml
@@ -24,16 +24,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>43811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>43811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -52,9 +48,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_43_complex_reconnect_B1.xml
+++ b/test/configuration/test_cases/test_43_complex_reconnect_B1.xml
@@ -23,16 +23,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>43812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>43812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -51,21 +47,19 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>43811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>43811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_43_complex_reconnect_B2.xml
+++ b/test/configuration/test_cases/test_43_complex_reconnect_B2.xml
@@ -25,16 +25,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>43812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>43812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -53,21 +49,19 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>43811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>43811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_44_fast_discovery_server_tool_reconnect.xml
+++ b/test/configuration/test_cases/test_44_fast_discovery_server_tool_reconnect.xml
@@ -35,16 +35,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>44811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>44811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -58,16 +54,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>44811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>44811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -81,16 +73,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>44811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>44811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -104,16 +92,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>44811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>44811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>

--- a/test/configuration/test_cases/test_45_trivial_client_reconnect_client.xml
+++ b/test/configuration/test_cases/test_45_trivial_client_reconnect_client.xml
@@ -21,16 +21,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>45811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>45811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>

--- a/test/configuration/test_cases/test_45_trivial_client_reconnect_server.xml
+++ b/test/configuration/test_cases/test_45_trivial_client_reconnect_server.xml
@@ -17,9 +17,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_46_guidless_discovery.xml
+++ b/test/configuration/test_cases/test_46_guidless_discovery.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <simples>
+        <simple name="client1" profile_name="UDP_client1_server1">
+            <subscriber topic="topic1" />
+        </simple>
+        <simple name="client2" profile_name="UDP_client2_server1">
+            <publisher topic="topic1"/>
+        </simple>
+    </simples>
+
+    <snapshots file="./test_46_guidless_discovery.snapshot~">
+        <snapshot time="6">Know each other and server</snapshot>
+    </snapshots>
+
+    <profiles>
+        <participant profile_name="UDP_client1_server1"> </participant>
+        <participant profile_name="UDP_client2_server1"> </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+    </profiles>
+</DS>

--- a/test/configuration/test_cases/test_47_guidless_server_double_ping.xml
+++ b/test/configuration/test_cases/test_47_guidless_server_double_ping.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <servers>
+        <server name="server1" profile_name="UDP_server1"/>
+        <server name="server2" profile_name="UDP_server2"/>
+        <server name="server3" profile_name="UDP_server3"/>
+    </servers>
+
+    <clients>
+        <client name="client1_server1" profile_name="UDP_client1_server1">
+            <publisher topic="topic1"/>
+        </client>
+        <client name="client1_server2" profile_name="UDP_client1_server2">
+            <subscriber topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_47_guidless_server_double_ping.snapshot~">
+        <snapshot time="6">test_47_guidless_server_double_ping_snapshot_1</snapshot>
+    </snapshots>
+
+    <profiles>
+        <participant profile_name="UDP_client1_server1" >
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>47811</port>
+                                </udpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="UDP_client1_server2" >
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>47812</port>
+                                </udpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="UDP_server1">
+        <rtps>
+            <builtin>
+                <discovery_config>
+                    <discoveryProtocol>SERVER</discoveryProtocol>
+                    <initialAnnouncements>
+                        <count>5</count>
+                    </initialAnnouncements>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
+                    <leaseDuration>DURATION_INFINITY</leaseDuration>
+                </discovery_config>
+                <metatrafficUnicastLocatorList>
+                    <locator>
+                        <udpv4>
+                            <address>127.0.0.1</address>
+                            <port>47811</port>
+                        </udpv4>
+                    </locator>
+                </metatrafficUnicastLocatorList>
+            </builtin>
+        </rtps>
+        </participant>
+
+        <participant profile_name="UDP_server2">
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>SERVER</discoveryProtocol>
+                        <initialAnnouncements>
+                            <count>5</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                    <metatrafficUnicastLocatorList>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>47812</port>
+                            </udpv4>
+                        </locator>
+                    </metatrafficUnicastLocatorList>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="UDP_server3">
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryServersList>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>47811</port>
+                                </udpv4>
+                            </locator>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>47812</port>
+                                </udpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <discoveryProtocol>SERVER</discoveryProtocol>
+                        <initialAnnouncements>
+                            <count>5</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                    <metatrafficUnicastLocatorList>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>47813</port>
+                            </udpv4>
+                        </locator>
+                    </metatrafficUnicastLocatorList>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_48_guidless_complex.xml
+++ b/test/configuration/test_cases/test_48_guidless_complex.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- S1 and S2 are created with fastdds tool and connected with env_var.
+         Server 3 must know both servers and clients must know their matching
+         participants:
+         S1: S2 & S3 & C1 & C2 & C3
+         C1: C2
+         C2: C1 & C3
+         C3: C2 -->
+
+    <servers>
+        <server name="server3" profile_name="UDP_server3"/>
+    </servers>
+
+    <clients>
+        <client name="client1_server1" profile_name="UDP_client1_server1">
+            <publisher topic="topic1"/>
+        </client>
+        <client name="client1_server2" profile_name="UDP_client1_server2">
+            <subscriber topic="topic1"/>
+            <publisher topic="topic2"/>
+        </client>
+        <client name="client1_server3" profile_name="UDP_client1_server3">
+            <publisher topic="topic1"/>
+            <subscriber topic="topic2"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_48_guidless_complex.snapshot~">
+        <snapshot time="6">test_48_guidless_complex_snapshot_1</snapshot>
+    </snapshots>
+
+    <profiles>
+        <participant profile_name="UDP_client1_server1" >
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>48811</port>
+                                </udpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="UDP_client1_server2" >
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>48812</port>
+                                </udpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="UDP_client1_server3" >
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>48813</port>
+                                </udpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="UDP_server3">
+            <rtps>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>SERVER</discoveryProtocol>
+                        <initialAnnouncements>
+                            <count>5</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                    <metatrafficUnicastLocatorList>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>48813</port>
+                            </udpv4>
+                        </locator>
+                    </metatrafficUnicastLocatorList>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+        <topic profile_name="topic2">
+            <name>topic_2</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_50_environment_modification.xml
+++ b/test/configuration/test_cases/test_50_environment_modification.xml
@@ -37,11 +37,11 @@
     </simples>
 
 
-    <snapshots file="./test_39_environment_modification~">
-        <snapshot time="4">test_39_environment_modification_initial</snapshot>
-        <snapshot time="7">test_39_environment_modification_add_server2</snapshot>
-        <snapshot time="12">test_39_environment_modification_add_server1</snapshot>
-        <snapshot time="16">test_39_environment_modification_final</snapshot>
+    <snapshots file="./test_50_environment_modification~">
+        <snapshot time="4">test_50_environment_modification_initial</snapshot>
+        <snapshot time="7">test_50_environment_modification_add_server2</snapshot>
+        <snapshot time="12">test_50_environment_modification_add_server1</snapshot>
+        <snapshot time="16">test_50_environment_modification_final</snapshot>
     </snapshots>
 
     <environment>
@@ -58,16 +58,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>38811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>38811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -95,16 +91,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.01.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>38812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>38812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -126,9 +118,11 @@
                     <discovery_config>
                         <discoveryProtocol>SERVER</discoveryProtocol>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>
@@ -154,9 +148,11 @@
                             <nanosec>20000000</nanosec>
                         </clientAnnouncementPeriod>
                         <initialAnnouncements>
-                            <count>0</count>
+                            <count>5</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseAnnouncement>
+                            <nanosec>500000000</nanosec>
+                        </leaseAnnouncement>
                         <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                     <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_60_disconnection_A.xml
+++ b/test/configuration/test_cases/test_60_disconnection_A.xml
@@ -13,7 +13,7 @@
 
     <snapshots file="./test_60_disconnection_A.snapshot~">
         <snapshot time="2">Knows all</snapshot>
-        <snapshot time="5">Do not know server and client B</snapshot>
+        <snapshot time="6">Do not know server and client B</snapshot>
     </snapshots>
 
     <profiles>
@@ -25,16 +25,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>46811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>46811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -53,9 +49,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_60_disconnection_B.xml
+++ b/test/configuration/test_cases/test_60_disconnection_B.xml
@@ -24,16 +24,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.32">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>46812</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>46812</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -52,21 +48,19 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <discoveryServersList>
-                        <RemoteServer prefix="44.49.53.43.53.45.52.56.45.52.5F.31">
-                            <metatrafficUnicastLocatorList>
-                                <locator>
-                                    <udpv4>
-                                        <address>127.0.0.1</address>
-                                        <port>46811</port>
-                                    </udpv4>
-                                </locator>
-                            </metatrafficUnicastLocatorList>
-                        </RemoteServer>
+                        <locator>
+                            <udpv4>
+                                <address>127.0.0.1</address>
+                                <port>46811</port>
+                            </udpv4>
+                        </locator>
                     </discoveryServersList>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_61_superclient_environment_variable.xml
+++ b/test/configuration/test_cases/test_61_superclient_environment_variable.xml
@@ -48,16 +48,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -76,16 +72,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -104,16 +96,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -132,16 +120,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -160,16 +144,12 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <udpv4>
-                                            <address>127.0.0.1</address>
-                                            <port>01811</port>
-                                        </udpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <udpv4>
+                                    <address>127.0.0.1</address>
+                                    <port>01811</port>
+                                </udpv4>
+                            </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
                             <count>0</count>
@@ -188,9 +168,11 @@
                 <discovery_config>
                     <discoveryProtocol>SERVER</discoveryProtocol>
                     <initialAnnouncements>
-                        <count>0</count>
+                        <count>5</count>
                     </initialAnnouncements>
-                    <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                    <leaseAnnouncement>
+                        <nanosec>500000000</nanosec>
+                    </leaseAnnouncement>
                     <leaseDuration>DURATION_INFINITY</leaseDuration>
                 </discovery_config>
                 <metatrafficUnicastLocatorList>

--- a/test/configuration/test_cases/test_95_tcpv4_cli.xml
+++ b/test/configuration/test_cases/test_95_tcpv4_cli.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
+    <!-- In order to avoid extra channel connections between TCP participants
+         we will use the whitelist to force the clients to send their locators
+         with localhost. Otherwise, the server would not reuse the initial
+         channel created and it might cause a failure in the connection,
+         depending of the value of the random logical port assigned.
+         This could be avoided by using default GUIDs. -->
+
     <clients>
         <client name="client1" profile_name="TCPv4_client_1" listening_port="0">
             <subscriber topic="topic1"/>
@@ -21,15 +28,21 @@
                 <transport_id>transport_client_1</transport_id>
                 <type>TCPv4</type>
                 <listening_ports>
-                    <port>42101</port>
+                    <port>0</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>lo</address>
+                </interfaceWhiteList>
             </transport_descriptor>
             <transport_descriptor>
                 <transport_id>transport_client_2</transport_id>
                 <type>TCPv4</type>
                 <listening_ports>
-                    <port>42102</port>
+                    <port>0</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>lo</address>
+                </interfaceWhiteList>
             </transport_descriptor>
         </transport_descriptors>
 

--- a/test/configuration/test_cases/test_95_tcpv4_cli.xml
+++ b/test/configuration/test_cases/test_95_tcpv4_cli.xml
@@ -21,14 +21,14 @@
                 <transport_id>transport_client_1</transport_id>
                 <type>TCPv4</type>
                 <listening_ports>
-                    <port>0</port>
+                    <port>42101</port>
                 </listening_ports>
             </transport_descriptor>
             <transport_descriptor>
                 <transport_id>transport_client_2</transport_id>
                 <type>TCPv4</type>
                 <listening_ports>
-                    <port>0</port>
+                    <port>42102</port>
                 </listening_ports>
             </transport_descriptor>
         </transport_descriptors>
@@ -44,17 +44,13 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <tcpv4>
-                                            <address>127.0.0.1</address>
-                                            <physical_port>42100</physical_port>
-                                            <port>42100</port>
-                                        </tcpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>42100</physical_port>
+                                    <port>42100</port>
+                                </tcpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -72,17 +68,13 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <tcpv4>
-                                            <address>127.0.0.1</address>
-                                            <physical_port>42100</physical_port>
-                                            <port>42100</port>
-                                        </tcpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>42100</physical_port>
+                                    <port>42100</port>
+                                </tcpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>

--- a/test/configuration/test_cases/test_96_tcpv6_cli.xml
+++ b/test/configuration/test_cases/test_96_tcpv6_cli.xml
@@ -10,7 +10,7 @@
         </client>
     </clients>
 
-    <snapshots file="./test_96_TCPv6_cli.snapshot">
+    <snapshots file="./test_96_tcpv6_cli.snapshot">
         <snapshot time="5">Knows all</snapshot>
     </snapshots>
 

--- a/test/configuration/test_cases/test_96_tcpv6_cli.xml
+++ b/test/configuration/test_cases/test_96_tcpv6_cli.xml
@@ -21,14 +21,14 @@
                 <transport_id>transport_client_1</transport_id>
                 <type>TCPv6</type>
                 <listening_ports>
-                    <port>0</port>
+                    <port>42101</port>
                 </listening_ports>
             </transport_descriptor>
             <transport_descriptor>
                 <transport_id>transport_client_2</transport_id>
                 <type>TCPv6</type>
                 <listening_ports>
-                    <port>0</port>
+                    <port>42102</port>
                 </listening_ports>
             </transport_descriptor>
         </transport_descriptors>
@@ -44,17 +44,13 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <tcpv6>
-                                            <address>::1</address>
-                                            <physical_port>42100</physical_port>
-                                            <port>42100</port>
-                                        </tcpv6>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <tcpv6>
+                                    <address>::1</address>
+                                    <physical_port>42100</physical_port>
+                                    <port>42100</port>
+                                </tcpv6>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -72,17 +68,13 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <tcpv6>
-                                            <address>::1</address>
-                                            <physical_port>42100</physical_port>
-                                            <port>42100</port>
-                                        </tcpv6>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <tcpv6>
+                                    <address>::1</address>
+                                    <physical_port>42100</physical_port>
+                                    <port>42100</port>
+                                </tcpv6>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>

--- a/test/configuration/test_cases/test_96_tcpv6_cli.xml
+++ b/test/configuration/test_cases/test_96_tcpv6_cli.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
+    <!-- In order to avoid extra channel connections between TCP participants
+         we will use the whitelist to force the clients to send their locators
+         with localhost. Otherwise, the server would not reuse the initial
+         channel created and it might cause a failure in the connection,
+         depending of the value of the random logical port assigned.
+         This could be avoided by using default GUIDs. -->
+
     <clients>
         <client name="client1" profile_name="TCPv6_client_1" listening_port="0">
             <subscriber topic="topic1"/>
@@ -21,15 +28,21 @@
                 <transport_id>transport_client_1</transport_id>
                 <type>TCPv6</type>
                 <listening_ports>
-                    <port>42101</port>
+                    <port>0</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>::1</address>
+                </interfaceWhiteList>
             </transport_descriptor>
             <transport_descriptor>
                 <transport_id>transport_client_2</transport_id>
                 <type>TCPv6</type>
                 <listening_ports>
-                    <port>42102</port>
+                    <port>0</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>::1</address>
+                </interfaceWhiteList>
             </transport_descriptor>
         </transport_descriptors>
 

--- a/test/configuration/test_cases/test_97_tcpv4_env_var.xml
+++ b/test/configuration/test_cases/test_97_tcpv4_env_var.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
+    <!-- Force the clients ports to be higher than the one of the server. This will ensure
+         than an extra CONNECT channel is created when the new locator without localhost
+         address is received. In normal behavior this will be avoided by using default guids
+         and letting Fast DDS convert the remote locators, but it cannot be done here
+         because we need to verify with a fixed snapshot. -->
+
     <servers>
         <server name="server" profile_name="TCPv4_server"/>
     </servers>
@@ -27,6 +33,9 @@
                 <listening_ports>
                     <port>42100</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>lo</address>
+                </interfaceWhiteList>
             </transport_descriptor>
             <transport_descriptor>
                 <transport_id>transport_client_1</transport_id>
@@ -34,6 +43,9 @@
                 <listening_ports>
                     <port>0</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>lo</address>
+                </interfaceWhiteList>
             </transport_descriptor>
             <transport_descriptor>
                 <transport_id>transport_client_2</transport_id>
@@ -41,6 +53,9 @@
                 <listening_ports>
                     <port>0</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>lo</address>
+                </interfaceWhiteList>
             </transport_descriptor>
         </transport_descriptors>
 

--- a/test/configuration/test_cases/test_97_tcpv4_env_var.xml
+++ b/test/configuration/test_cases/test_97_tcpv4_env_var.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Force the clients ports to be higher than the one of the server. This will ensure
-         than an extra CONNECT channel is created when the new locator without localhost
-         address is received. In normal behavior this will be avoided by using default guids
-         and letting Fast DDS convert the remote locators, but it cannot be done here
-         because we need to verify with a fixed snapshot. -->
+    <!-- In order to avoid extra channel connections between TCP participants
+         we will use the whitelist to force the clients to send their locators
+         with localhost. Otherwise, the server would not reuse the initial
+         channel created and it might cause a failure in the connection,
+         depending of the value of the random logical port assigned.
+         This could be avoided by using default GUIDs. -->
 
     <servers>
         <server name="server" profile_name="TCPv4_server"/>

--- a/test/configuration/test_cases/test_98_tcpv6_env_var.xml
+++ b/test/configuration/test_cases/test_98_tcpv6_env_var.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
+    <!-- In order to avoid extra channel connections between TCP participants
+         we will use the whitelist to force the clients to send their locators
+         with localhost. Otherwise, the server would not reuse the initial
+         channel created and it might cause a failure in the connection,
+         depending of the value of the random logical port assigned.  -->
+
     <servers>
         <server name="server" profile_name="TCPv6_server"/>
     </servers>
@@ -15,7 +21,7 @@
     </simples>
 
     <snapshots file="./test_98_tcpv6_env_var.snapshot~">
-        <snapshot time="5">Knows all</snapshot>
+        <snapshot time="10">Knows all</snapshot>
     </snapshots>
 
     <profiles>
@@ -27,6 +33,9 @@
                 <listening_ports>
                     <port>42100</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>::1</address>
+                </interfaceWhiteList>
             </transport_descriptor>
             <transport_descriptor>
                 <transport_id>transport_client_1</transport_id>
@@ -34,6 +43,9 @@
                 <listening_ports>
                     <port>0</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>::1</address>
+                </interfaceWhiteList>
             </transport_descriptor>
             <transport_descriptor>
                 <transport_id>transport_client_2</transport_id>
@@ -41,6 +53,9 @@
                 <listening_ports>
                     <port>0</port>
                 </listening_ports>
+                <interfaceWhiteList>
+                    <address>::1</address>
+                </interfaceWhiteList>
             </transport_descriptor>
         </transport_descriptors>
 

--- a/test/configuration/test_cases/test_98_tcpv6_env_var.xml
+++ b/test/configuration/test_cases/test_98_tcpv6_env_var.xml
@@ -5,7 +5,8 @@
          we will use the whitelist to force the clients to send their locators
          with localhost. Otherwise, the server would not reuse the initial
          channel created and it might cause a failure in the connection,
-         depending of the value of the random logical port assigned.  -->
+         depending of the value of the random logical port assigned.
+         This could be avoided by using default GUIDs. -->
 
     <servers>
         <server name="server" profile_name="TCPv6_server"/>

--- a/test/configuration/test_cases/test_99_tcp.xml
+++ b/test/configuration/test_cases/test_99_tcp.xml
@@ -4,7 +4,6 @@
     <!--
         This test verifies that:
         - the clients can locate each others and server's publisher and subscribers.
-        - create dynamic types using Fast DDS xml schema.
         - create Publishers and Subscriber profiles
         - specify topics using attributes to constrain the number of profiles needed
     -->
@@ -18,21 +17,21 @@
 
     <clients>
         <client name="client1" profile_name="TCP_client_1" listening_port="27812">
-            <subscriber /> <!-- defaults to helloworld type -->
+            <subscriber topic="HelloWorldTopic"/>
             <subscriber topic="topic_1" />
             <subscriber topic="topic_2" />
             <publisher topic="topic_2" />
         </client>
         <client name="client2" profile_name="TCP_client_2" listening_port="27813">
-            <publisher />  <!-- defaults to helloworld type -->
+            <publisher topic="HelloWorldTopic"/>
             <publisher topic="topic_1" />
             <publisher topic="topic_1" />
             <subscriber topic="topic_2" />
         </client>
     </clients>
 
-    <snapshots file="./test_27_tcp.snapshot~">
-        <snapshot time="10">test_27_tcp_snapshot_1</snapshot>
+    <snapshots file="./test_99_tcp.snapshot~">
+        <snapshot time="10">test_99_tcp_snapshot_1</snapshot>
     </snapshots>
 
     <profiles>
@@ -44,8 +43,6 @@
                 <listening_ports>
                     <port>27811</port>
                 </listening_ports>
-                <calculate_crc>false</calculate_crc>
-                <check_crc>false</check_crc>
             </transport_descriptor>
         </transport_descriptors>
 
@@ -80,17 +77,13 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <tcpv4>
-                                            <address>127.0.0.1</address>
-                                            <physical_port>27811</physical_port>
-                                            <port>6339</port>
-                                        </tcpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>27811</physical_port>
+                                    <port>6339</port>
+                                </tcpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -105,17 +98,13 @@
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
-                            <RemoteServer prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f">
-                                <metatrafficUnicastLocatorList>
-                                    <locator>
-                                        <tcpv4>
-                                            <address>127.0.0.1</address>
-                                            <physical_port>27811</physical_port>
-                                            <port>6339</port>
-                                        </tcpv4>
-                                    </locator>
-                                </metatrafficUnicastLocatorList>
-                            </RemoteServer>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>27811</physical_port>
+                                    <port>6339</port>
+                                </tcpv4>
+                            </locator>
                         </discoveryServersList>
                     </discovery_config>
                 </builtin>
@@ -129,7 +118,12 @@
 
         <topic profile_name="topic_2">
             <name>topic_2</name>
-            <dataType>sample_type_2</dataType>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+        <topic profile_name="HelloWorldTopic">
+            <name>HelloWorldTopic</name>
+            <dataType>HelloWorld</dataType>
         </topic>
     </profiles>
 
@@ -139,20 +133,6 @@
                 <member name="index" type="uint32" />
                 <member name="message" type="string" />
             </struct>
-        </type>
-
-        <type>
-            <union name="sample_type_2">
-                <discriminator type="byte" />
-                <case>
-                    <caseDiscriminator value="0" />
-                    <member name="index" type="uint32" />
-                </case>
-                <case>
-                    <caseDiscriminator value="1" />
-                    <member name="message" type="string" />
-                </case>
-            </union>
         </type>
     </types>
 

--- a/test/configuration/test_solutions/test_05_server_double_ping.snapshot
+++ b/test/configuration/test_solutions/test_05_server_double_ping.snapshot
@@ -1,51 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1603440431948" process_time="8000" last_pdp_callback_time="4486" last_edp_callback_time="5935" someone="true">
+    <DS_Snapshot timestamp="1713162521369" process_time="4000" last_pdp_callback_time="1388" last_edp_callback_time="1840" someone="true">
         <description>test_05_server_double_ping_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="32"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="35">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="486"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="132"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="126"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="477">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="925"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="3034">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="4483"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="932">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1386"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="32"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="3034">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4483"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="132"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="126"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="928">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1385"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="42">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="494"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="480">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="930"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="146"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="144"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1037">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2482"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="129"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="131"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="927">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1385"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1034">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2482"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="932">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1386"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="143"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="34"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="479"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="26">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="26"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="4485">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5935"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1388">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1840"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="143"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="4486">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5935"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="522"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1387">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1839"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="41">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="41"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="29">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="29"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_06_diamond_servers.snapshot
+++ b/test/configuration/test_solutions/test_06_diamond_servers.snapshot
@@ -1,105 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1603443611076" process_time="15000" last_pdp_callback_time="4041" last_edp_callback_time="5040" someone="true">
+    <DS_Snapshot timestamp="1713168598168" process_time="2000" last_pdp_callback_time="1435" last_edp_callback_time="1886" someone="true">
         <description>test_06_diamond_servers_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="27"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="29"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="36">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1486"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="141"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="143"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="146"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="494">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="945"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1034">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2030"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="948">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="977"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1038">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2031"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="975">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1432"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="4040">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5034"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="979">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1433"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="143"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="33"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2029">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3034"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="144"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="147"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="141"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="947">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="977"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="40">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="493"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="498">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="947"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="2043">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3045"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="976">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1432"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="2039">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3043"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="979">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1433"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="143"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="33"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2033">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3034"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="236"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="146"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="141"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="946">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="977"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="2039">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3045"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="948">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="977"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="44">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="497"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="524">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="973"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="2041">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3043"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="979">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1432"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="148"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="150"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="3042">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4037"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="146"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="143"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="145"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="947">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="977"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1034">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2031"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="948">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="977"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1038">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2032"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="975">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1432"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="48">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1498"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="527">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="978"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="141"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="36">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="36"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="495"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="43">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="43"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="3032">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="4047"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1434">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1886"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="146"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="39">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="39"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="537"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="45">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="45"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="4036">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5033"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server4" discovered_timestamp="1434">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1886"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="147"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="4036">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5035"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="525"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="979">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1432"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="43">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="43"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="72">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="72"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="161"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="2035">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3045"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="540"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="979">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1433"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="47">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="47"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="76">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.34.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="76"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_09_servers_serial.snapshot
+++ b/test/configuration/test_solutions/test_09_servers_serial.snapshot
@@ -1,30 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1603720035888" process_time="10000" last_pdp_callback_time="3026" last_edp_callback_time="4475" someone="true">
+    <DS_Snapshot timestamp="1713169084679" process_time="3000" last_pdp_callback_time="934" last_edp_callback_time="1385" someone="true">
         <description>test_09_servers_serial_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="24"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="28">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="479"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="126"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="131"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="481">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="931"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="138"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="26"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="1026">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2475"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="129"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="127"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="934">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1385"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="141"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="3026">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4475"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="129"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="934">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1385"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="137"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="28">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="28"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="483"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="29">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="29"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_11_remote_servers.snapshot
+++ b/test/configuration/test_solutions/test_11_remote_servers.snapshot
@@ -1,108 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1603721327904" process_time="8000" last_pdp_callback_time="4043" last_edp_callback_time="5493" someone="true">
+    <DS_Snapshot timestamp="1713170105030" process_time="3000" last_pdp_callback_time="1398" last_edp_callback_time="1399" someone="true">
         <description>test_11_remote_servers_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="42">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1043"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="133">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="230"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2045">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="3043"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="138">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="233"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="47">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="498"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="492">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="943"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="156"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="42">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="42"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="134"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="34"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="45">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1045"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="137">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="233"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1044">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2043"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="945">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1396"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="158">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1043"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="233"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="138">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="346"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="44">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="44"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="37"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="3044">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4493"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="945">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1396"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="155"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2043">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="3043"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="494"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="945">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1396"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4043">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="5493"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="946">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1397"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="47">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="47"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="39">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="39"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1603721334904" process_time="15000" last_pdp_callback_time="11478" last_edp_callback_time="12745" someone="true">
+    <DS_Snapshot timestamp="1713170108030" process_time="6000" last_pdp_callback_time="1398" last_edp_callback_time="4007" someone="true">
         <description>test_11_remote_servers_snapshot_2</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="10000">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="10000"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="4003">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="4003"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="42">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1043"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="133">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="230"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2045">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="3043"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="138">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="233"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="47">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="498"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="492">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="943"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="156">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="10845"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="134">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="4005"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="42">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="42"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="34"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="45">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1045"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="137">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="233"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1044">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2043"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="945">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1396"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="11298">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="12745"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="233">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="4006"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="158">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1043"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="138">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="346"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="44">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="44"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="37"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="3044">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4493"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="945">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1396"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="155"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2043">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="3043"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="494"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="945">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1396"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4043">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="5493"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="946">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1397"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="47">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="47"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="39">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="39"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_12_virtual_topics.snapshot
+++ b/test/configuration/test_solutions/test_12_virtual_topics.snapshot
@@ -1,267 +1,270 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1603444275641" process_time="10000" last_pdp_callback_time="5059" last_edp_callback_time="6501" someone="true">
+    <DS_Snapshot timestamp="1713343235220" process_time="3000" last_pdp_callback_time="1915" last_edp_callback_time="2366" someone="true">
         <description>test_12_virtual_topics_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="26">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="26"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="37"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="32">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1056"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="144">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="160"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="1078">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="2068"/>
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="2064"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="150">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="190"/>
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="189"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="3084">
-                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="4506"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="156">
+                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="181"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="46">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="497"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.35" guid_entity="0.0.1.c1" server="true" alive="true" name="server5" discovered_timestamp="153"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="504">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="954"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1047">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2067"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="995">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1009"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="2079">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3075"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1000">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1460"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="3074">
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4503"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="1009">
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1462"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="73">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1523"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="551">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1053">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2068"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1004">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="3072">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4502"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="1459">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1915"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="33">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="1040"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="147">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="160"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="31">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="31"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="40">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="40"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="36">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="1064"/>
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="1062"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="145">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="160"/>
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="160"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="2055">
-                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="3062"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="151">
+                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="181"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.35" guid_entity="0.0.1.c1" server="true" alive="true" name="server5" discovered_timestamp="43"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1039">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2046"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.35" guid_entity="0.0.1.c1" server="true" alive="true" name="server5" discovered_timestamp="149"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="956">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="996"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="49">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="501"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="543">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="993"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1061">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2063"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1000">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1459"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="2076">
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3053"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="1009">
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1012"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="2043">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3044"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="1001">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1014"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="77">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="529"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="553">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1003"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="2062">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3061"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="1459">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1914"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="1069">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="2066"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="150">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="166"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="152">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1057"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="147">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="160"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="35">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="35"/>
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="35"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="42">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="43"/>
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="42"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="490">
-                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="1489"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="149">
+                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="192"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2064">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3076"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.35" guid_entity="0.0.1.c1" server="true" alive="true" name="server5" discovered_timestamp="152"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="956">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="996"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1047">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2067"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="995">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="52">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="504"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="547">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="998"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="3075">
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4503"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="1009">
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1013"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="3072">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4502"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="1002">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1461"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1056">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2068"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1004">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1011"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="80">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1530"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="555">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1457"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="3065">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="4059"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="152">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="167"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="1072">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="2057"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="150">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="166"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="488">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="1054"/>
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="1052"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="145">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="160"/>
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="160"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="38">
-                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="38"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="45">
+                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="45"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="4058">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5060"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.35" guid_entity="0.0.1.c1" server="true" alive="true" name="server5" discovered_timestamp="154"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="956">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="997"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="3062">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="4060"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="995">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1051">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2056"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1000">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1460"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="5059">
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="6501"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="1009">
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1459"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="5056">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="6501"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="1002">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1014"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="3068">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="4060"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1004">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="2054">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3070"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="1459">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1914"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.35" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="1066">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="2066"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="156">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="170"/>
             </ptdi>
             <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="152">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1056"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="181"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="1078">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="2068"/>
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="2066"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="154">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="189"/>
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="189"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="3084">
-                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="4506"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="159">
+                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="172"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2064">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3075"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="956">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="997"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1048">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2068"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="995">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="2079">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3076"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1000">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1459"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="83">
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1533"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server5" discovered_timestamp="558">
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1008"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="3071">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4503"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="1002">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1014"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1054">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2068"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1004">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="3074">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4504"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="1459">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1914"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="158"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2040">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="3045"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="505"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="955">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="997"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="3043">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="4048"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="957">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="997"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="45">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="45"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="50">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="50"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="3040">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="4047"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1011">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1461"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="4044">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5048"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1462">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1916"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="1064">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="2064"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="995">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="150"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2061">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3072"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="544"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="998">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="48">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="48"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="91">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="91"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="3059">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="4057"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="1000">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="1459"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="164"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="4056">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5056"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="548"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1001">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1459"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="51">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="51"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="96">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="96"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="5049">
-                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="6497"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="1009">
+                <subscriber type="HelloWorld" topic="topic_3" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.4" discovered_timestamp="1461"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.35" guid_entity="0.0.1.c1" server="true" alive="true" name="server5" discovered_timestamp="197"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="83">
-                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="83"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.35" guid_entity="0.0.1.c1" server="true" alive="true" name="server5" discovered_timestamp="559"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="107">
+                <publisher type="HelloWorld" topic="topic_3" guid_prefix="63.6c.69.65.6e.74.31.5f.73.35.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="107"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="159"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="72">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="72"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="552"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="99">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="99"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="3041">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="4046"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1012">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1461"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="150"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="3070">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4503"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="554"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="1015">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1460"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="76">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="76"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="102">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="102"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="3071">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4504"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="1915">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2366"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="165"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="3060">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="4059"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="1044"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server2" discovered_timestamp="1459">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1914"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="80">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="80"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="104">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="104"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_14_disposals_remote_servers.snapshot
+++ b/test/configuration/test_solutions/test_14_disposals_remote_servers.snapshot
@@ -1,250 +1,256 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1603866126063" process_time="8000" last_pdp_callback_time="4036" last_edp_callback_time="5486" someone="true">
+    <DS_Snapshot timestamp="1713356499658" process_time="3000" last_pdp_callback_time="530" last_edp_callback_time="530" someone="true">
         <description>test_14_disposals_remote_servers_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="35">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1036"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="117">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="217"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2038">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="3036"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="125">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="217"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="40">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="492"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="127">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="478"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="149"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="34"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="118"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="18"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="38">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1038"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="123">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="217"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1038">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2036"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="479">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="151">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1035"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="125"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="124">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="479"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="37"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="23"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="3037">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4485"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="479">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="147"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2036">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="3036"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="127"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="479">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="529"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4036">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="5486"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="479">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="529"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="40">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="40"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="27">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="27"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1603866133063" process_time="15000" last_pdp_callback_time="4036" last_edp_callback_time="10837" someone="true">
+    <DS_Snapshot timestamp="1713356502658" process_time="6000" last_pdp_callback_time="530" last_edp_callback_time="4002" someone="true">
         <description>test_14_disposals_remote_servers_snapshot_2</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="35">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1036"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="117">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="217"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2038"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="40">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="492"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="125"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="127">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="478"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="149"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="34"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="118"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="18"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="38"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1038">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2036"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="123"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="479">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="151">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1035"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="125"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="124">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="479"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="3037">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4485"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="479">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="147"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2036">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="3036"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="127"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="479">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="529"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4036"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="40">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="40"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="479"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="27">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="27"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1603866143063" process_time="25000" last_pdp_callback_time="4036" last_edp_callback_time="21540" someone="true">
+    <DS_Snapshot timestamp="1713356505658" process_time="9000" last_pdp_callback_time="530" last_edp_callback_time="7005" someone="true">
         <description>test_14_disposals_remote_servers_snapshot_3</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="35"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2038">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="21002"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="117"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="125">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7004"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="40">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="492"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="127">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="478"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="149"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="38">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="20003"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="118"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="123">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7004"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1038">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2036"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="479">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="151"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="20001"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="125"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7003"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="3037">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4485"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="479">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="147"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2036"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4036">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="21540"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="127"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="479"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="479">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7005"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="40">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="40"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="27">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="27"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1603866153063" process_time="35000" last_pdp_callback_time="4036" last_edp_callback_time="30704" someone="true">
+    <DS_Snapshot timestamp="1713356509658" process_time="13000" last_pdp_callback_time="530" last_edp_callback_time="10004" someone="true">
         <description>test_14_disposals_remote_servers_snapshot_4</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="35"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2038">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="21002"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="117"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="125">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7004"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="40"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="127"/>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="149"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="38">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="20003"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="118"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="123">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7004"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1038"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="479"/>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="151"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="20001"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="125"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7003"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="3037"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="479"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="147"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2036"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4036">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="21540"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="127"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="479"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="479">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7005"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="40"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="27"/>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1603866163063" process_time="45000" last_pdp_callback_time="40406" last_edp_callback_time="30704" someone="true">
+    <DS_Snapshot timestamp="1713356513658" process_time="17000" last_pdp_callback_time="14006" last_edp_callback_time="10004" someone="true">
         <description>test_14_disposals_remote_servers_snapshot_5</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="35"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2038">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="21002"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="117"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="125">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7004"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="149"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="38">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="20003"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="118"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="123">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7004"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="151"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="20001"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="125"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7003"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1603866173063" process_time="55000" last_pdp_callback_time="53455" last_edp_callback_time="54906" someone="true">
+    <DS_Snapshot timestamp="1713356517658" process_time="21000" last_pdp_callback_time="18517" last_edp_callback_time="18518" someone="true">
         <description>test_14_disposals_remote_servers_snapshot_6</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="35"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2038">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="21002"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="117"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="125">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7004"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="50003">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="50453"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="18112">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="18463"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="149"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="38">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="20003"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="118"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="123">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7004"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="51005">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="52454"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="18465">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="18515"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="151"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="20001"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="125"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="7003"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="53455">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="54906"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="18465">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="18515"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="50115"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="51004">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="52454"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="18113"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="18465">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="18516"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="50003">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="50003"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18008">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="18008"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1603866183063" process_time="65000" last_pdp_callback_time="53455" last_edp_callback_time="60706" someone="true">
+    <DS_Snapshot timestamp="1713356521658" process_time="25000" last_pdp_callback_time="22007" last_edp_callback_time="22005" someone="true">
         <description>test_14_disposals_remote_servers_snapshot_7</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="35"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="50003">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="50453"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="117"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="18112">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="18463"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="149"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="51005">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="52454"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="118"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="18465">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="18515"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="50115"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="50003">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="50003"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="18113"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18008">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="18008"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_19_disposals_break_builtin_connections.snapshot
+++ b/test/configuration/test_solutions/test_19_disposals_break_builtin_connections.snapshot
@@ -1,119 +1,125 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1604055917704" process_time="10000" last_pdp_callback_time="4012" last_edp_callback_time="5462" someone="true">
+    <DS_Snapshot timestamp="1713357189199" process_time="3000" last_pdp_callback_time="526" last_edp_callback_time="526" someone="true">
         <description>test_19_disposals_break_builtin_connections_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="11">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1015"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="116">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="476"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2015">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="3465"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="121">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="475"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="17">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="468"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="119">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="472"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="125"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="11">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="11"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="120"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="14"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="14">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1112"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="117">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="475"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1012">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2012"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="474">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="524"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="112">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1014"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="121"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="120">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="476"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="13">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="13"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="15">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="15"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2015">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3465"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="474">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="524"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="124"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2012">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="3012"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="120"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="477">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="524"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4012">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="5462"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="478">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="524"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="16"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="17"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1604055927704" process_time="20000" last_pdp_callback_time="16003" last_edp_callback_time="15002" someone="true">
+    <DS_Snapshot timestamp="1713357192199" process_time="6000" last_pdp_callback_time="4010" last_edp_callback_time="4480" someone="true">
         <description>test_19_disposals_break_builtin_connections_snapshot_2</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2015">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="3465"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="121">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="475"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="17">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="468"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="119">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="472"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="13">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="13"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="121"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="15">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="15"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2015">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3465"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="474">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="524"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="124"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4012">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="5462"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="120"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="478">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="524"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="16"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="17"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1604055967704" process_time="60000" last_pdp_callback_time="26007" last_edp_callback_time="27457" someone="true">
+    <DS_Snapshot timestamp="1713357195199" process_time="9000" last_pdp_callback_time="7515" last_edp_callback_time="7514" someone="true">
         <description>test_19_disposals_break_builtin_connections_snapshot_3</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2015">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="3465"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="121">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="475"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="17">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="468"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="119">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="472"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="25006">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="25457"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="7111">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="7462"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="13">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="13"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="121"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="15">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="15"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2015">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3465"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="474">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="524"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="7464">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="7514"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="124"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4012">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="5462"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="120"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="478">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="524"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="16"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="17"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="25118"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="26007">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="27457"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="7114"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="7464">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="7514"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="25005">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="25005"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="7008">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="7008"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_20_break_builtin_connections.snapshot
+++ b/test/configuration/test_solutions/test_20_break_builtin_connections.snapshot
@@ -1,107 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1608213072557" process_time="3000" last_pdp_callback_time="925" last_edp_callback_time="1374" someone="true">
+    <DS_Snapshot timestamp="1713357486790" process_time="3000" last_pdp_callback_time="532" last_edp_callback_time="532" someone="true">
         <description>test_20_break_builtin_connections_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="server2" discovered_timestamp="18">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="server2" discovered_timestamp="114">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="213"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="135">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="122">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="211"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="470"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="124">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="476"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="server2" discovered_timestamp="18">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="133"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="123"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="server2" discovered_timestamp="121">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="479"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="17"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="21">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="21"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="925">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1374"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="478">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="server2" discovered_timestamp="471">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="923"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="server2" discovered_timestamp="478">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="530"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="472">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="924"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="479">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="529"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="23"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1608213078557" process_time="9000" last_pdp_callback_time="7011" last_edp_callback_time="7011" someone="true">
+    <DS_Snapshot timestamp="1713357492790" process_time="9000" last_pdp_callback_time="7513" last_edp_callback_time="8040" someone="true">
         <description>test_20_break_builtin_connections_snapshot_2</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="135">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="122">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="211"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="470"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="124">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="476"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="17"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="123"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="21">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="21"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="925">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1374"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="478">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="472">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="924"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="479">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="529"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="23"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1608213082557" process_time="13000" last_pdp_callback_time="10457" last_edp_callback_time="10907" someone="true">
+    <DS_Snapshot timestamp="1713357496790" process_time="13000" last_pdp_callback_time="10516" last_edp_callback_time="10514" someone="true">
         <description>test_20_break_builtin_connections_snapshot_3</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="135">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="122">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="211"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="470"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="124">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="476"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="10004">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10455"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="10111">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10461"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="17"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="123"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="21">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="21"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="925">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1374"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="478">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server1" discovered_timestamp="10463">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10514"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="472">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="924"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="124"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="479">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="529"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="23"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="10016"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="10457">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="10907"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="10113"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="10463">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="10514"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="10003">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10003"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="10008">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10008"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_25_backup_compatibility.snapshot
+++ b/test/configuration/test_solutions/test_25_backup_compatibility.snapshot
@@ -1,98 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1604588102552" process_time="10000" last_pdp_callback_time="4014" last_edp_callback_time="5013" someone="true">
+    <DS_Snapshot timestamp="1713965739495" process_time="5000" last_pdp_callback_time="4198" last_edp_callback_time="3747" someone="true">
         <description>test_25_backup_compatibility_snapshot_1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="12">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1015"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="427">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1845"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="2014">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="3015"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="674">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="786"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="467"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="434">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="785"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1015">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2014"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1778">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3296"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="3015">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4465"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="822">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="836"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="110"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="11">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="11"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="452"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="326">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="326"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="14">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1015"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="529">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1885"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1012">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2012"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1153">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1812"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="19">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="513"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="925">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1736"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1015">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2015"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1344">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1852"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="14">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1015"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="675"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="674">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1845"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="13">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="13"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="330">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="330"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2014">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3015"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="785">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="823"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1015">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="2014"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1778">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3296"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="22">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="473"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="821"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="124"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2012">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="3014"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="435"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="1846">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1975"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4014">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="5013"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="787">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="823"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="16"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="334">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="334"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="3013">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="4014"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="3297">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3747"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="2014">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3016"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="924"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1975">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3192"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="18"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="337">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="337"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="3016">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="4465"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="2295">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="3192"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="2015">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="3016"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="1846">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.4" discovered_timestamp="1975"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="134">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="1015"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="471">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.4" discovered_timestamp="822"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="2015">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3017"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="3297">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.32.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="3747"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="21">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="21"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="370">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.33.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="370"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_28_slow_arise_interconnection.snapshot
+++ b/test/configuration/test_solutions/test_28_slow_arise_interconnection.snapshot
@@ -1,234 +1,236 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1612341148811" process_time="5000" last_pdp_callback_time="477" last_edp_callback_time="492" someone="true">
+    <DS_Snapshot timestamp="1713366779257" process_time="3000" last_pdp_callback_time="937" last_edp_callback_time="1388" someone="true">
         <description>c11 and c21 knows each other</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="485">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="932"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="24">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="487">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="935"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="487"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="31">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="31"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="476">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="488"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="937">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1388"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="476">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="488"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="528"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="937">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1388"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="23"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="33">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="33"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1612341158811" process_time="15000" last_pdp_callback_time="477" last_edp_callback_time="492" someone="true">
+    <DS_Snapshot timestamp="1713366784257" process_time="8000" last_pdp_callback_time="5889" last_edp_callback_time="6340" someone="true">
         <description>s3 knows c11 and c21</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="485">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="932"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="24">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="487">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="935"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="5434">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5885"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="24">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="5436">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5888"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="487"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="5436"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="31">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="31"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="476">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="488"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="937">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1388"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="476">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="488"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="528"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="5438"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="937">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1388"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="23"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="33">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="33"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1612341168811" process_time="25000" last_pdp_callback_time="20463" last_edp_callback_time="20482" someone="true">
+    <DS_Snapshot timestamp="1713366789257" process_time="13000" last_pdp_callback_time="10916" last_edp_callback_time="11367" someone="true">
         <description>c32 and c42 knows each other and s1 and s3</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="485">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="932"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="24">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="487">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="935"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="20007">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20457"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="10461">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10911"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="20012">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20462"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="10464">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="10914"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="5434">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5885"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="24">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="5436">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5888"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="20007">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20457"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="10461">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10911"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="20012">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20462"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="10464">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="10914"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="487"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="5436"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="31">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="31"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="476">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="488"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="937">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1388"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="476">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="488"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="528"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="5438"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="937">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1388"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="23"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="33">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="33"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20011">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20011"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="10463"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="10464"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="10013">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10012"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="20463">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20476"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="10915">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="11366"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="20463">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20476"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="10467"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="10465"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="10915">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="11366"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20011">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20011"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="10013">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="10013"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1612341183811" process_time="40000" last_pdp_callback_time="20463" last_edp_callback_time="20482" someone="true">
+    <DS_Snapshot timestamp="1713366801257" process_time="25000" last_pdp_callback_time="15417" last_edp_callback_time="15867" someone="true">
         <description>all servers knows each other</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="15"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="15111"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="15118"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="485">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="932"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="24">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="487">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="935"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="20007">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20457"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="10461">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10911"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="20012">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20462"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="10464">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="10914"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="16"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="17"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="15114"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="15016"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="15020">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="15110"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="24">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="15021">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="15111"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="20007">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20457"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="15021">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="15111"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="20012">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20462"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="15021">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="15111"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="17"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="15117"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="15019"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="5434">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5885"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="24">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="5436">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5888"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="20007">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20457"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="10461">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10911"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="20012">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20462"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="10464">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="10914"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="487"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="15339"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="5436"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="31">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="31"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="476">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="488"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_sub1" discovered_timestamp="937">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1388"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="476">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="488"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="528"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="15343"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="5438"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="937">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1388"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="23"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="33">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="33"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="20120"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20011">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20011"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="10463"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="15414"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="10464"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="10013">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10012"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="20463">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20476"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4_sub2" discovered_timestamp="10915">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="11366"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="20119"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="20463">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20476"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="10467"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="15417"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="10465"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3_pub2" discovered_timestamp="10915">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="11366"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20011">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="20011"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="10013">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="10013"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_29_server_ping_late_joiner.snapshot
+++ b/test/configuration/test_solutions/test_29_server_ping_late_joiner.snapshot
@@ -1,30 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1603380772979" process_time="10000" last_pdp_callback_time="4180" last_edp_callback_time="0" someone="true">
+    <DS_Snapshot timestamp="1713367290624" process_time="3000" last_pdp_callback_time="1109" last_edp_callback_time="0" someone="true">
         <description>3.4 knows each other</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1"/>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="4180"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="1021"/>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4180"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="1024"/>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1603380772979" process_time="10000" last_pdp_callback_time="4180" last_edp_callback_time="0" someone="true">
-        <description>1.2 knows each other, 2.3 knows each other</description>
+    <DS_Snapshot timestamp="1713367294624" process_time="7000" last_pdp_callback_time="4119" last_edp_callback_time="0" someone="true">
+        <description>all know each other</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="4067"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="4111"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4117"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="4118"/>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="4180"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4180"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="4114"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4012"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="4017"/>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="4067"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="4180"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="4117"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="4014"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="1021"/>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="4180"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="4117"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="4017"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="1024"/>
         </ptdb>
     </DS_Snapshot>
 </DS_Snapshots>

--- a/test/configuration/test_solutions/test_30_connect_locally_with_remote_entity.snapshot
+++ b/test/configuration/test_solutions/test_30_connect_locally_with_remote_entity.snapshot
@@ -1,45 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1612341148811" process_time="5000" last_pdp_callback_time="477" last_edp_callback_time="492" someone="true">
-        <description>S2 knows C1 but C1 does not know S2</description>
+    <DS_Snapshot timestamp="1713425659876" process_time="9000" last_pdp_callback_time="7226" last_edp_callback_time="17" someone="true">
+        <description>S1 knows C1 PDP. S2 only knows S1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
-            </ptdi>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="7110"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="5020"/>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_pub1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
-            </ptdi>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="7113"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="5022"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="17"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1612341158811" process_time="15000" last_pdp_callback_time="477" last_edp_callback_time="492" someone="true">
+    <DS_Snapshot timestamp="1713425662876" process_time="12000" last_pdp_callback_time="10019" last_edp_callback_time="10472" someone="true">
         <description>All knows each other</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="7110"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="5020">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10018"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="19">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="7113"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="10018">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="10472"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="131"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="131"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="5022"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="10019"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="17"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_31_matched_servers_not_share_info.snapshot
+++ b/test/configuration/test_solutions/test_31_matched_servers_not_share_info.snapshot
@@ -1,108 +1,114 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1613041949464" process_time="3000" last_pdp_callback_time="1380" last_edp_callback_time="1830" someone="true">
+    <DS_Snapshot timestamp="1713426172114" process_time="3000" last_pdp_callback_time="1391" last_edp_callback_time="1842" someone="true">
         <description>all servers know each other and client1</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="9">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="9"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="9"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="24">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="25"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="24"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="12"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="924">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="1378"/>
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="1377"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="133"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="139">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="487"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="487"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="468"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="484">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="935"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="13">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="468"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="467"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="135">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="486"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="486"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="466">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="922"/>
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="922"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="137">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="487"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="487"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="469">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="920"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="937">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1389"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="469">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="922"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="922"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="139">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="487"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="486"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="465"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="14"/>
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="14"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="133"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="29">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="29"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="29"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="921">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1377"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="937">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1389"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="129"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="1380">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="1830"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="486"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="937">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="1389"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="16"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="31">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="31"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1613041953464" process_time="7000" last_pdp_callback_time="5462" last_edp_callback_time="5912" someone="true">
-        <description>server1 not know remote client2</description>
+    <DS_Snapshot timestamp="1713426176114" process_time="7000" last_pdp_callback_time="6365" last_edp_callback_time="6816" someone="true">
+        <description>server1 knows remote client2</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="9">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="9"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="9"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="24">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="25"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="24"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="924">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="1378"/>
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="1377"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="139">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="487"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="487"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="468"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="484">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="935"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="5912">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="6363"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="469">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="922"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="922"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="139">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.2.4" discovered_timestamp="487"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="486"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="14"/>
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="14"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="29">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="29"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.3" discovered_timestamp="29"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="921">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1377"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="937">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1389"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="5009">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5460"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="5458">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5910"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="129"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="1380">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="1830"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="486"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="937">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.2.4" discovered_timestamp="1389"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="16">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="16"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="31">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="31"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2_server3" discovered_timestamp="6365">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="6816"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="5461">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="5912"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="5912">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="6363"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="5122"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="5462">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5912"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="5460"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="5913">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="6363"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="5008">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5008"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="5007">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="5007"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_32_superclient_trivial.snapshot
+++ b/test/configuration/test_solutions/test_32_superclient_trivial.snapshot
@@ -1,84 +1,103 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1613467567290" process_time="2000" last_pdp_callback_time="476" last_edp_callback_time="927" someone="true">
+    <DS_Snapshot timestamp="1714119819816" process_time="4001" last_pdp_callback_time="961" last_edp_callback_time="1412" someone="true">
         <description>test_32_superclient_trivial</description>
         <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="15">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="465"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="133"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client" discovered_timestamp="484">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="935"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="18">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="468"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="487">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="937"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="21">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="471"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="489">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="939"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="23">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="473"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="491">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="940"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="25">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="475"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="509">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="959"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="28"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client5" discovered_timestamp="513"/>
+        </ptdb>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="136"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client" discovered_timestamp="937">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="961"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="939">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="962"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="940">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="961"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="942">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="962"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="960">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1412"/>
+            </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="15"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="15">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="15"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="486"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="31">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="31"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="469">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="927"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="938">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="963"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="471">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="926"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="940">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="962"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="474">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="927"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="943">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="963"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="476">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="926"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="961">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1412"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="129"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="469">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="926"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="487"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client" discovered_timestamp="938">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.30.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="961"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="18"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="34">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="34"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="471">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="927"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="940">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="962"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="129"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="471">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="926"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="490"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="940">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="961"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="20">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="20"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="37">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="37"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="129"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="23">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="23"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="492"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="39">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="39"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="476">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="926"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="960">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1412"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="130"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="476">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="926"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="510"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="961">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1412"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="25">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="25"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="57">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="57"/>
             </ptdi>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="130"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="514"/>
         </ptdb>
     </DS_Snapshot>
 </DS_Snapshots>

--- a/test/configuration/test_solutions/test_33_superclient_complex.snapshot
+++ b/test/configuration/test_solutions/test_33_superclient_complex.snapshot
@@ -1,330 +1,336 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1613469904855" process_time="5000" last_pdp_callback_time="1454" last_edp_callback_time="1905" someone="true">
+    <DS_Snapshot timestamp="1714485900572" process_time="20000" last_pdp_callback_time="1089" last_edp_callback_time="1542" someone="true">
         <description>test_33_superclient_complex</description>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="19">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="66"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="66"/>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" name="server1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="136">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="149"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="149"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="26">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="477"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="141"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="147"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="498">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="947"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="480">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="518"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="518"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="951">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="993"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="994"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="518">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="548"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="991">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1003"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="517">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="547"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="547"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="995">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1004"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1004"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="69">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="520"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="543">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="992"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="72">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="529"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="78">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="533"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="533"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="533"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="19"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="18">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="19"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="18"/>
-            </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="22"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="477">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="518"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="29">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="479"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="479"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="484">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="517"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="67">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="517"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="517"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="521">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="72">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="525"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="534">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1001"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="22">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="67"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="67"/>
-            </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="24"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="519">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="530"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="480">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="518"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="518"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="32">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="483"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="66">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="517"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="517"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="1001">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1452"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="526">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="530"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.37.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client3" discovered_timestamp="75"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1002">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1452"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1453"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1453"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="75">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="481"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="481"/>
-            </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="76"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="530">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="983"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="520">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="529"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="530"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="484">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="517"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="517">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="529"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="529"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="1453">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1904"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="532">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="983"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1453">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1905"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1905"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1905"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="69"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="26">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="26"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="520">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1001"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="534">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1001"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="72">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="481"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="520">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="530"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="29">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="29"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="29"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="518">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="530"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="517">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="530"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="530"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="1001">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1452"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="484">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="518"/>
-            </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="75"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="519">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="983"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="32">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="32"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="532">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="983"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1454">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1905"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="72"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="75"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="518">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="532"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="66">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="66"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="66"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1002">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1452"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1453"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="70"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="70">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="521"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="521"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="478">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="521"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="521">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1002"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="549">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="549">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1001"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="69">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="69"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="531">
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="546">
                 <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1002"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="535">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1002"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="550">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1004"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1004"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1004"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="72"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="73">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="522"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="522"/>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" name="server2">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="136"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="36">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="37"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="36"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="478">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="522"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="140"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="147"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="949">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="992"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="480">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="522"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="522"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="498">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="948"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="949"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="519">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="530"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="991">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1045"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="518">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="530"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="530"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="541">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="991"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="991"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="522">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="595">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="994"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="72">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="72"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="545">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="999"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="534">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1001"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.37.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="76">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="525"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="525"/>
-            </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="75"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="531">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="983"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="520">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="532"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="532"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="484">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="525"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="517">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="531"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="531"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="1453">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1904"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="533">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="983"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1453">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1905"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1905"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1905"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.37.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client3" discovered_timestamp="600"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="603">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1005"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1005"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1005"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="78"/>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="78">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="527"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="528"/>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" name="server3">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="143"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="142">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="500"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="499"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="478">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="528"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" server="true" alive="true" name="server4" discovered_timestamp="145"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="948">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="992"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="520">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1001"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1001"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="951">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="993"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="993"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="550">
-                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="537">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="989"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="550">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1001"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="539">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="991"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="991"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="522">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="995">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1010"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="531">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1002"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="1003">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1011"/>
             </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="77">
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="77"/>
-                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="78"/>
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="78"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.37.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client3" discovered_timestamp="546"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1007">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1010"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1011"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1011"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.34" guid_entity="0.0.1.c1" name="server4">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="149"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="147">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="500"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="499"/>
+            </ptdi>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="146"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="948">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="992"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="951">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="993"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="994"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="991">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1003"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="994">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1003"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1003"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="995">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1041"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="1004">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1042"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1011">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1042"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1042"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1043"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="client1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="499"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="43">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="43"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="998">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1037"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1008">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1015"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1015"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="client2">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="499">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="951"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="1003">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1013"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="45">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="45"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="45"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="1047">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1541"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="997">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1013"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1013"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="1002">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1013"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="client3">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="991">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="1020"/>
+            </ptdi>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="539"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="998">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1005"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="86">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="86"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="1012">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1020"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1013">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1020"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="client4">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="542"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="540"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="997">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1009"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="88">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="88"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="89"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1007">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1010"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1010"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="super_client1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="542"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="544">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="994"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="993"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="948">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="992"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="951">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="993"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="994"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="1007">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1022"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="997">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1013"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1013"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="91">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="91"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="1004">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1014"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1008">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1014"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1014"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1014"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="super_client2">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="545"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="546">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="995"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="1003"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="948">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="999"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="951">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="994"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="994"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="1008">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1039"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="1000">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1020"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1020"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="995">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1020"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="93">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="93"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1010">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1020"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1021"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1021"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.37.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="super_client3">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="550">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="1009"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="1001"/>
+            </ptdi>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="548"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="1001">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1033"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="951">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1009"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1009"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="991">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1032"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="994">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1033"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1033"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="1004">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1033"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="1006">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1017"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client4" discovered_timestamp="1010">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1033"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1034"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="1033"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="super_client4">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="548"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="551">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.2.4" discovered_timestamp="1008"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.3" discovered_timestamp="1002"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="948">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="998"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="951">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1007"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="1008"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="1010">
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1037"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="999">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1037"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1037"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client1" discovered_timestamp="995">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.35.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1021"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="super_client2" discovered_timestamp="1004">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.36.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1021"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="96">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="96"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="97"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.38.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="97"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_34_connect_locally_with_remote_server.snapshot
+++ b/test/configuration/test_solutions/test_34_connect_locally_with_remote_server.snapshot
@@ -1,49 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1613645249093" process_time="8000" last_pdp_callback_time="6115" last_edp_callback_time="6566" someone="true">
-        <description>s3 knows s1 (remotely) but s1 does not know s3</description>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="15">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="15"/>
+    <DS_Snapshot timestamp="1714986131865" process_time="8001" last_pdp_callback_time="6218" last_edp_callback_time="6108" someone="true">
+        <description>s3 knows s1 and s1 knows s3</description>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" name="server1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="17"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="5015"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="120"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="6107"/>
         </ptdb>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="5015">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="6004"/>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" name="server2">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="118">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="5121"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="6003"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="6105"/>
         </ptdb>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="6115">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="6566"/>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" name="server3">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="6107">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="6108"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="6115"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="6106"/>
         </ptdb>
     </DS_Snapshot>
-    <DS_Snapshot timestamp="1613645254093" process_time="13000" last_pdp_callback_time="11454" last_edp_callback_time="11905" someone="true">
+    <DS_Snapshot timestamp="1714986136865" process_time="13000" last_pdp_callback_time="11910" last_edp_callback_time="12362" someone="true">
         <description>s1 knows s3 and its client</description>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="15">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="15"/>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" name="server1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="17"/>
             </ptdi>
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="10015"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="11454">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="11905"/>
-            </ptdi>
-        </ptdb>
-        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="6115">
-                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="6566"/>
-            </ptdi>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="11003">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="11453"/>
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="6107"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="11910">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="12362"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="11115"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="11003">
-                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="11003"/>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" name="server3">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="6107">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.3" discovered_timestamp="6108"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="11459">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="11909"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" name="client1_server3">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.33" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="11461"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="11010">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="11010"/>
             </ptdi>
         </ptdb>
     </DS_Snapshot>

--- a/test/configuration/test_solutions/test_36_dns_environment_variable_setup.snapshot
+++ b/test/configuration/test_solutions/test_36_dns_environment_variable_setup.snapshot
@@ -1,24 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
-    <DS_Snapshot timestamp="1628691092169" process_time="2000" last_pdp_callback_time="133" last_edp_callback_time="0" someone="true">
+    <DS_Snapshot timestamp="1713447051476" process_time="2000" last_pdp_callback_time="119" last_edp_callback_time="0" someone="true">
         <description>test_36_dns_environment_variable_setup_snapshot_1</description>
-        <ptdb guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="19"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="23"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client3" discovered_timestamp="27"/>
-            <ptdi guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client4" discovered_timestamp="34"/>
-        </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="133"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Default Server number 0" discovered_timestamp="116"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="133"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Default Server number 0" discovered_timestamp="118"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.33.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="133"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Default Server number 0" discovered_timestamp="118"/>
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.34.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
-            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="133"/>
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Default Server number 0" discovered_timestamp="119"/>
         </ptdb>
     </DS_Snapshot>
 </DS_Snapshots>

--- a/test/configuration/test_solutions/test_46_guidless_discovery.snapshot
+++ b/test/configuration/test_solutions/test_46_guidless_discovery.snapshot
@@ -2,7 +2,7 @@
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
     <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
         <description>Know each other and server</description>
-        <ptdb guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.c1" name="client1">
             <ptdi guid_prefix="01.0f.f4.a0.6d.ec.9c.84.fb.df.05.a3" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="113"/>
             <ptdi guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="14"/>
@@ -11,7 +11,7 @@
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.70.ae.72.ff.01.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="923"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="01.0f.f4.a0.70.ae.72.ff.01.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.70.ae.72.ff.01.00.00.00" guid_entity="0.0.1.c1" name="client2">
             <ptdi guid_prefix="01.0f.f4.a0.6d.ec.9c.84.fb.df.05.a3" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="118"/>
             <ptdi guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="471">
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="923"/>

--- a/test/configuration/test_solutions/test_46_guidless_discovery.snapshot
+++ b/test/configuration/test_solutions/test_46_guidless_discovery.snapshot
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>Know each other and server</description>
+        <ptdb guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.6d.ec.9c.84.fb.df.05.a3" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="113"/>
+            <ptdi guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.70.ae.72.ff.01.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="472">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.70.ae.72.ff.01.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="01.0f.f4.a0.70.ae.72.ff.01.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.6d.ec.9c.84.fb.df.05.a3" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="118"/>
+            <ptdi guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="471">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.70.ae.72.ff.00.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="923"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.70.ae.72.ff.01.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.70.ae.72.ff.01.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_47_guidless_server_double_ping.snapshot
+++ b/test/configuration/test_solutions/test_47_guidless_server_double_ping.snapshot
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713778430160" process_time="6001" last_pdp_callback_time="1397" last_edp_callback_time="1855" someone="true">
+        <description>test_47_guidless_server_double_ping_snapshot_1</description>
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="140"/>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.02.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="129"/>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="482">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="932"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="937">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="1393"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="137"/>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.02.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="129"/>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="936">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1393"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="485">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="936"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.02.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="138"/>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="133"/>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="936">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1393"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="937">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="1394"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="486"/>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="30">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="30"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1397">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="1855"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="488"/>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1396">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1854"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="33">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="33"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_47_guidless_server_double_ping.snapshot
+++ b/test/configuration/test_solutions/test_47_guidless_server_double_ping.snapshot
@@ -2,7 +2,7 @@
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
     <DS_Snapshot timestamp="1713778430160" process_time="6001" last_pdp_callback_time="1397" last_edp_callback_time="1855" someone="true">
         <description>test_47_guidless_server_double_ping_snapshot_1</description>
-        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1" name="server1">
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="140"/>
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.02.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="129"/>
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="482">
@@ -12,7 +12,7 @@
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="1393"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1" name="server2">
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="137"/>
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.02.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="129"/>
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="936">
@@ -22,7 +22,7 @@
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="936"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.02.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.02.00.00.00" guid_entity="0.0.1.c1" name="server3">
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="138"/>
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="133"/>
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="936">
@@ -32,7 +32,7 @@
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="1394"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" name="client1_server1">
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.00.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server1" discovered_timestamp="486"/>
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="30">
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="30"/>
@@ -41,7 +41,7 @@
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.4" discovered_timestamp="1855"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.04.00.00.00" guid_entity="0.0.1.c1" name="client1_server2">
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.01.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server2" discovered_timestamp="488"/>
             <ptdi guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1396">
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.0a.b3.1d.d9.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1854"/>

--- a/test/configuration/test_solutions/test_48_guidless_complex.snapshot
+++ b/test/configuration/test_solutions/test_48_guidless_complex.snapshot
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713781238422" process_time="6000" last_pdp_callback_time="1393" last_edp_callback_time="1437" someone="true">
+        <description>test_48_guidless_complex_snapshot_1</description>
+        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.00.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.03.08.3c.c2.78.31.f0.9f" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="114"/>
+            <ptdi guid_prefix="01.0f.f4.a0.1c.20.4b.70.45.e0.dc.c2" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="119"/>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="928">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1391"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="932">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="1390"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1389"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="484">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="935"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="935"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.1c.20.4b.70.45.e0.dc.c2" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="476"/>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="25">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="25"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1392">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="1426"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.03.08.3c.c2.78.31.f0.9f" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="481"/>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1391">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1407"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="28">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="30"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="28"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server3" discovered_timestamp="1392">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="1408"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1408"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.00.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="484"/>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1392">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="1421"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1421"/>
+            </ptdi>
+            <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="33">
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="33"/>
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="33"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_48_guidless_complex.snapshot
+++ b/test/configuration/test_solutions/test_48_guidless_complex.snapshot
@@ -2,7 +2,7 @@
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
     <DS_Snapshot timestamp="1713781238422" process_time="6000" last_pdp_callback_time="1393" last_edp_callback_time="1437" someone="true">
         <description>test_48_guidless_complex_snapshot_1</description>
-        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.00.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.00.00.00.00" guid_entity="0.0.1.c1" name="server3">
             <ptdi guid_prefix="01.0f.f4.a0.03.08.3c.c2.78.31.f0.9f" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="114"/>
             <ptdi guid_prefix="01.0f.f4.a0.1c.20.4b.70.45.e0.dc.c2" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="119"/>
             <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="928">
@@ -17,7 +17,7 @@
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="935"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1" name="client1_server1">
             <ptdi guid_prefix="01.0f.f4.a0.1c.20.4b.70.45.e0.dc.c2" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="476"/>
             <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="25">
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="25"/>
@@ -26,7 +26,7 @@
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="1426"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.c1" name="client1_server2">
             <ptdi guid_prefix="01.0f.f4.a0.03.08.3c.c2.78.31.f0.9f" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Guidless Server" discovered_timestamp="481"/>
             <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="1391">
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.01.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1407"/>
@@ -40,7 +40,7 @@
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.3" discovered_timestamp="1408"/>
             </ptdi>
         </ptdb>
-        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.c1">
+        <ptdb guid_prefix="01.0f.f4.a0.a2.c1.a2.63.03.00.00.00" guid_entity="0.0.1.c1" name="client1_server3">
             <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.00.00.00.00" guid_entity="0.0.1.c1" server="true" alive="true" name="server3" discovered_timestamp="484"/>
             <ptdi guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server2" discovered_timestamp="1392">
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="01.0f.f4.a0.a2.c1.a2.63.02.00.00.00" guid_entity="0.0.2.4" discovered_timestamp="1421"/>

--- a/test/configuration/test_solutions/test_50_environment_modification.snapshot
+++ b/test/configuration/test_solutions/test_50_environment_modification.snapshot
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
     <DS_Snapshot timestamp="1632834082789" process_time="8047" last_pdp_callback_time="5185" last_edp_callback_time="5323" someone="true">
-        <description>test_39_environment_modification_initial</description>
+        <description>test_50_environment_modification_initial</description>
         <ptdb guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1">
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="5073">
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5323"/>
@@ -20,7 +20,7 @@
         </ptdb>
     </DS_Snapshot>
     <DS_Snapshot timestamp="1632834086789" process_time="12047" last_pdp_callback_time="10052" last_edp_callback_time="5323" someone="true">
-        <description>test_39_environment_modification_add_server2</description>
+        <description>test_50_environment_modification_add_server2</description>
         <ptdb guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1">
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="5073">
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5323"/>
@@ -39,7 +39,7 @@
         </ptdb>
     </DS_Snapshot>
     <DS_Snapshot timestamp="1632834090789" process_time="16047" last_pdp_callback_time="14543" last_edp_callback_time="14994" someone="true">
-        <description>test_39_environment_modification_add_server1</description>
+        <description>test_50_environment_modification_add_server1</description>
         <ptdb guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1">
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="5073">
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="5323"/>
@@ -68,7 +68,7 @@
         </ptdb>
     </DS_Snapshot>
     <DS_Snapshot timestamp="1632834096789" process_time="22047" last_pdp_callback_time="18330" last_edp_callback_time="18780" someone="true">
-        <description>test_39_environment_modification_final</description>
+        <description>test_50_environment_modification_final</description>
         <ptdb guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1">
             <ptdi guid_prefix="44.53.01.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="true" alive="true" name="server_2" discovered_timestamp="18054"/>
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_server1" discovered_timestamp="5073">

--- a/test/configuration/test_solutions/test_99_tcp.snapshot
+++ b/test/configuration/test_solutions/test_99_tcp.snapshot
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
     <DS_Snapshot timestamp="1605771117973" process_time="10000" last_pdp_callback_time="1217" last_edp_callback_time="2216" someone="true">
-        <description>test_27_tcp_snapshot_1</description>
+        <description>test_99_tcp_snapshot_1</description>
         <ptdb guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.c1">
             <ptdi guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="10">
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.2.4" discovered_timestamp="10"/>
-                <publisher type="sample_type_2" topic="topic_2" guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.3" discovered_timestamp="10"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.3" discovered_timestamp="10"/>
             </ptdi>
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="215">
                 <subscriber type="HelloWorld" topic="HelloWorldTopic" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="465"/>
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="465"/>
-                <subscriber type="sample_type_2" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="465"/>
-                <publisher type="sample_type_2" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="465"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="465"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="465"/>
             </ptdi>
             <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="320">
-                <subscriber type="sample_type_2" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="1270"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="1270"/>
                 <publisher type="HelloWorld" topic="HelloWorldTopic" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1020"/>
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="1020"/>
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.3.3" discovered_timestamp="1020"/>
@@ -22,16 +22,16 @@
         </ptdb>
         <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
             <ptdi guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="310">
-                <publisher type="sample_type_2" topic="topic_2" guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.3" discovered_timestamp="1228"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.3" discovered_timestamp="1228"/>
             </ptdi>
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="114">
                 <subscriber type="HelloWorld" topic="HelloWorldTopic" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="115"/>
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="115"/>
-                <subscriber type="sample_type_2" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="115"/>
-                <publisher type="sample_type_2" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="114"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="115"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="114"/>
             </ptdi>
             <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="1218">
-                <subscriber type="sample_type_2" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="2216"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="2216"/>
                 <publisher type="HelloWorld" topic="HelloWorldTopic" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2215"/>
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="2216"/>
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.3.3" discovered_timestamp="2216"/>
@@ -40,15 +40,15 @@
         <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
             <ptdi guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="679">
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.2.4" discovered_timestamp="1228"/>
-                <publisher type="sample_type_2" topic="topic_2" guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.3" discovered_timestamp="2216"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f" guid_entity="0.0.1.3" discovered_timestamp="2216"/>
             </ptdi>
             <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="1217">
                 <subscriber type="HelloWorld" topic="HelloWorldTopic" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.2.4" discovered_timestamp="2216"/>
                 <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.3.4" discovered_timestamp="2216"/>
-                <publisher type="sample_type_2" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2216"/>
+                <publisher type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="2216"/>
             </ptdi>
             <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="219">
-                <subscriber type="sample_type_2" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="220"/>
+                <subscriber type="HelloWorld" topic="topic_2" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.4.4" discovered_timestamp="220"/>
                 <publisher type="HelloWorld" topic="HelloWorldTopic" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="219"/>
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.2.3" discovered_timestamp="220"/>
                 <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.3.3" discovered_timestamp="220"/>

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -1417,11 +1417,33 @@
                         "generate_validation":
                         {
                             "disposals": false,
-                            "server_endpoints": false
+                            "server_endpoints": true
                         },
                         "ground_truth_validation":
                         {
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_36_dns_environment_variable_setup.snapshot"
+                        }
+                    }
+                },
+
+                "fastddstool_1":
+                {
+                    "kill_time": 3,
+                    "tool_config":
+                    {
+                        "id" : 0,
+                        "udp_address": "localhost",
+                        "udp_port": 36811
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
                         }
                     }
                 }
@@ -1736,7 +1758,7 @@
 
                 "serverB_2":
                 {
-                    "creation_time": 13,
+                    "creation_time": 16,
                     "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_41_reconnect_with_clients_B.xml",
                     "validation":
                     {
@@ -1816,7 +1838,7 @@
 
                 "serverB_2":
                 {
-                    "creation_time": 13,
+                    "creation_time": 16,
                     "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_42_server_reconnect_with_clients_B.xml",
                     "validation":
                     {
@@ -2487,7 +2509,7 @@
                         "generate_validation":
                         {
                             "disposals": false,
-                            "server_endpoints": false
+                            "server_endpoints": true
                         },
                         "ground_truth_validation":
                         {

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -65,6 +65,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_01_trivial.snapshot"
                         }
                     }
@@ -100,6 +101,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_02_single_server_medium.snapshot"
                         }
                     }
@@ -136,6 +138,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_03_single_server_large.snapshot"
                         }
                     }
@@ -171,6 +174,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_04_server_ping.snapshot"
                         }
                     }
@@ -206,6 +210,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_05_server_double_ping.snapshot"
                         }
                     }
@@ -241,6 +246,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_06_diamond_servers.snapshot"
                         }
                     }
@@ -276,6 +282,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_07_server_endpoints_two_servers.snapshot"
                         }
                     }
@@ -311,6 +318,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_08_server_endpoints_four_clients.snapshot"
                         }
                     }
@@ -346,6 +354,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_09_servers_serial.snapshot"
                         }
                     }
@@ -381,6 +390,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_10_server_redundancy.snapshot"
                         }
                     }
@@ -416,6 +426,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_11_remote_servers.snapshot"
                         }
                     }
@@ -451,6 +462,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_12_virtual_topics.snapshot"
                         }
                     }
@@ -486,6 +498,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_13_disposals_single_server.snapshot"
                         }
                     }
@@ -521,6 +534,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_14_disposals_remote_servers.snapshot"
                         }
                     }
@@ -556,6 +570,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_15_disposals_client_servers.snapshot"
                         }
                     }
@@ -591,6 +606,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_16_lease_duration_single_client.snapshot"
                         }
                     }
@@ -632,6 +648,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_17_lease_duration_remove_client_server.snapshot"
                         }
                     }
@@ -668,6 +685,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_18_disposals_remote_servers_multiprocess.snapshot"
                         }
                     }
@@ -733,6 +751,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_19_disposals_break_builtin_connections.snapshot"
                         }
                     }
@@ -768,6 +787,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_20_break_builtin_connections.snapshot"
                         }
                     }
@@ -809,6 +829,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_21_disposals_remote_server_trivial.snapshot"
                         }
                     }
@@ -851,6 +872,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_22_environment_variable_setup.snapshot"
                         }
                     }
@@ -881,6 +903,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_23_fast_discovery_server_tool.snapshot"
                         }
                     }
@@ -938,6 +961,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_24_backup_1.snapshot"
                         }
                     }
@@ -962,6 +986,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_24_backup.snapshot"
                         }
                     }
@@ -998,6 +1023,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_25_backup_compatibility.snapshot"
                         }
                     }
@@ -1034,6 +1060,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_26_backup_restore.snapshot"
                         }
                     }
@@ -1059,6 +1086,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_26_backup_restore_1.snapshot"
                         }
                     }
@@ -1089,6 +1117,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_27_slow_arise.snapshot"
                         }
                     }
@@ -1119,6 +1148,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_28_slow_arise_interconnection.snapshot"
                         }
                     }
@@ -1149,6 +1179,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_29_server_ping_late_joiner.snapshot"
                         }
                     }
@@ -1179,6 +1210,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_30_connect_locally_with_remote_entity.snapshot"
                         }
                     }
@@ -1209,6 +1241,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_31_matched_servers_not_share_info.snapshot"
                         }
                     }
@@ -1239,6 +1272,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_32_superclient_trivial.snapshot"
                         }
                     }
@@ -1270,6 +1304,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_33_superclient_complex.snapshot"
                         }
                     }
@@ -1300,6 +1335,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_34_connect_locally_with_remote_server.snapshot"
                         }
                     }
@@ -1330,6 +1366,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_35_fds_two_connected_servers_with_clients.snapshot"
                         }
                     }
@@ -1421,6 +1458,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_36_dns_environment_variable_setup.snapshot"
                         }
                     }
@@ -1473,6 +1511,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_37_dns_fast_discovery_server_tool.snapshot"
                         }
                     }
@@ -1534,6 +1573,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_38_self_connection.snapshot"
                         }
                     }
@@ -1573,6 +1613,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_39_trivial_reconnect_A.snapshot"
                         }
                     }
@@ -1614,6 +1655,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_39_trivial_reconnect_B.snapshot"
                         }
                     }
@@ -1654,6 +1696,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_40_trivial_server_reconnect_A.snapshot"
                         }
                     }
@@ -1696,6 +1739,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_40_trivial_server_reconnect_B.snapshot"
                         }
                     }
@@ -1735,6 +1779,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_41_reconnect_with_clients_A.snapshot"
                         }
                     }
@@ -1776,6 +1821,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_41_reconnect_with_clients_B.snapshot"
                         }
                     }
@@ -1815,6 +1861,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_42_server_reconnect_with_clients_A.snapshot"
                         }
                     }
@@ -1856,6 +1903,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_42_server_reconnect_with_clients_B.snapshot"
                         }
                     }
@@ -1910,6 +1958,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_43_complex_reconnect_A1.snapshot"
                         }
                     }
@@ -1940,6 +1989,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_43_complex_reconnect_A2.snapshot"
                         }
                     }
@@ -1969,6 +2019,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_43_complex_reconnect_B1.snapshot"
                         }
                     }
@@ -1999,6 +2050,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_43_complex_reconnect_B2.snapshot"
                         }
                     }
@@ -2029,6 +2081,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_44_fast_discovery_server_tool_reconnect.snapshot"
                         }
                     }
@@ -2107,6 +2160,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_45_trivial_client_reconnect_client.snapshot"
                         }
                     }
@@ -2179,6 +2233,11 @@
                         {
                             "disposals": false,
                             "server_endpoints": true
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_46_guidless_discovery.snapshot"
                         }
                     }
                 },
@@ -2237,6 +2296,11 @@
                         {
                             "disposals": false,
                             "server_endpoints": true
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_47_guidless_server_double_ping.snapshot"
                         }
                     }
                 }
@@ -2268,6 +2332,11 @@
                         {
                             "disposals": false,
                             "server_endpoints": true
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_48_guidless_complex.snapshot"
                         }
                     }
                 },
@@ -2369,6 +2438,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_50_environment_modification.snapshot"
                         }
                     }
@@ -2403,6 +2473,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_60_disconnection_A.snapshot"
                         }
                     }
@@ -2426,6 +2497,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_60_disconnection_B.snapshot"
                         }
                     }
@@ -2467,6 +2539,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_61_superclient_environment_variable.snapshot"
                         }
                     }
@@ -2501,6 +2574,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_95_tcpv4_cli.snapshot"
                         }
                     }
@@ -2556,6 +2630,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_96_tcpv6_cli.snapshot"
                         }
                     }
@@ -2618,6 +2693,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_97_tcpv4_env_var.snapshot"
                         }
                     }
@@ -2659,6 +2735,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_98_tcpv6_env_var.snapshot"
                         }
                     }
@@ -2694,6 +2771,7 @@
                         },
                         "ground_truth_validation":
                         {
+                            "guidless": false,
                             "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_99_tcp.snapshot"
                         }
                     }

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -2147,6 +2147,187 @@
             }
         },
 
+        "test_46_guidless_discovery":
+        {
+            "processes":
+            {
+                "main":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_46_guidless_discovery.xml",
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS_DISCOVERY_SERVER",
+                            "value": "127.0.0.1:46811"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_46_guidless_discovery.snapshot"
+                        },
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "generate_validation":
+                        {
+                            "disposals": false,
+                            "server_endpoints": true
+                        }
+                    }
+                },
+
+                "fastddstool_1":
+                {
+                    "kill_time": 7,
+                    "tool_config":
+                    {
+                        "udp_port": 46811
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                }
+            }
+        },
+
+        "test_47_guidless_server_double_ping":
+        {
+            "processes":
+            {
+                "main":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_47_guidless_server_double_ping.xml",
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS_DISCOVERY_SERVER",
+                            "value": "127.0.0.1:46811"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_47_guidless_server_double_ping.snapshot"
+                        },
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "generate_validation":
+                        {
+                            "disposals": false,
+                            "server_endpoints": true
+                        }
+                    }
+                }
+            }
+        },
+
+        "test_48_guidless_complex":
+        {
+            "processes":
+            {
+                "main":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_48_guidless_complex.xml",
+                    "validation":
+                    {
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_48_guidless_complex.snapshot"
+                        },
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "generate_validation":
+                        {
+                            "disposals": false,
+                            "server_endpoints": true
+                        }
+                    }
+                },
+
+                "fastddstool_1":
+                {
+                    "kill_time": 7,
+                    "tool_config":
+                    {
+                        "udp_port": 48811
+                    },
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS_DISCOVERY_SERVER",
+                            "value": "127.0.0.1:48812"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+
+                "fastddstool_2":
+                {
+                    "kill_time": 7,
+                    "tool_config":
+                    {
+                        "udp_port": 48812
+                    },
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS_DISCOVERY_SERVER",
+                            "value": "127.0.0.1:48813"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                }
+            }
+        },
+
         "test_50_environment_modification":
         {
             "description": [

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -317,11 +317,11 @@ def execute_validate_thread_test(
         try:
             # Try to set args for fastdds tool
             # If any is missing could not be an error
-            server_id = process_params['tool_config']['id']
-            server_udp_address = process_params['tool_config']['udp_address']
-            server_udp_port = process_params['tool_config']['udp_port']
-            server_tcp_port = process_params['tool_config']['tcp_address']
-            server_tcp_port = process_params['tool_config']['tcp_port']
+            server_id = process_params['tool_config'].get('id', None)
+            server_udp_address = process_params['tool_config'].get('udp_address', None)
+            server_udp_port = process_params['tool_config'].get('udp_port', None)
+            server_tcp_address = process_params['tool_config'].get('tcp_address', None)
+            server_tcp_port = process_params['tool_config'].get('tcp_port', None)
         except KeyError:
             pass
 
@@ -360,7 +360,10 @@ def execute_validate_thread_test(
 
     else:
         # Fastdds tool
-        process_args = [fds_path, '-i', str(server_id)]
+        process_args = [fds_path]
+        if server_id is not None:
+            process_args.append('-i')
+            process_args.append(str(server_id))
         if server_udp_address is not None:
             process_args.append('-l')
             process_args.append(str(server_udp_address))


### PR DESCRIPTION
This PR updates the infrastructure and configuration files of the Tests in order to keep compatibility with PR:

- https://github.com/eProsima/Fast-DDS/pull/4716

It also:

- Adds three new tests to specifically verify the GUIDLess functionality.
- Properly adds the TCP tests and fix them. 
- Minor improvements and deletions of unused parameters.

- This PR in on top of https://github.com/eProsima/Discovery-Server/pull/77 and must be merged after it.