### PR TITLE
[20936] Change backup restore order

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -126,8 +126,6 @@ set(TEST_CASE_LIST)
 
 # Test that are leaky and may fail
 set(FAIL_TEST_CASES
-    test_24_backup
-    test_25_backup_compatibility
     test_26_backup_restore
     test_33_superclient_complex
     test_99_tcp)

--- a/test/configuration/test_cases/test_24_backup.xml
+++ b/test/configuration/test_cases/test_24_backup.xml
@@ -2,7 +2,6 @@
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
   <!--
-
   This test verifies that the discovery info is properly serialized and deserialized by a backup server.
   This server is created twice by running twice the test_11_BACKUP_server.xml file:
     - The first time the discovery data is serialized to a backup file.
@@ -16,7 +15,7 @@
     </servers>
 
     <snapshots file="./test_24_backup.snapshot~">
-        <snapshot time="5">test_24_backup_snapshot_server</snapshot>
+        <snapshot time="10">test_24_backup_snapshot_server</snapshot>
     </snapshots>
 
     <profiles>

--- a/test/configuration/test_cases/test_24_backup_1.xml
+++ b/test/configuration/test_cases/test_24_backup_1.xml
@@ -13,19 +13,19 @@
 
     <clients>
         <client name="client1_server1" profile_name="UDP_client1_server1">
-            <subscriber /> <!-- defaults to helloworld type -->
+            <subscriber topic="HelloWorldTopic"/>
             <publisher topic="topic1"/>
             <publisher topic="topic2"/>
         </client>
         <client name="client2_server1" profile_name="UDP_client2_server1">
-            <publisher />  <!-- defaults to helloworld type -->
+            <publisher topic="HelloWorldTopic"/>
             <subscriber topic="topic1"/>
             <subscriber topic="topic2"/>
         </client>
     </clients>
 
     <snapshots file="./test_24_backup_1.snapshot~">
-        <snapshot time="7">test_24_backup_1_snapshot_clients</snapshot>
+        <snapshot time="10">test_24_backup_1_snapshot_clients</snapshot>
     </snapshots>
 
     <profiles>
@@ -83,6 +83,11 @@
 
         <topic profile_name="topic2">
             <name>topic_2</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+        <topic profile_name="HelloWorldTopic">
+            <name>HelloWorldTopic</name>
             <dataType>HelloWorld</dataType>
         </topic>
 

--- a/test/configuration/test_cases/test_26_backup_restore.xml
+++ b/test/configuration/test_cases/test_26_backup_restore.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
+    <!--
+        This test verifies that the backup server sends mathing PDP to its clients after
+        loading them from the backup file.
+    -->
+
     <servers>
         <server name="server" profile_name="UDP_server"/>
     </servers>
@@ -12,7 +17,7 @@
     </clients>
 
     <snapshots file="./test_26_backup_restore.snapshot~">
-        <snapshot time="2">test_26_backup_restore_snapshot_server</snapshot>
+        <snapshot time="4">test_26_backup_restore_snapshot_server</snapshot>
     </snapshots>
 
     <profiles>
@@ -62,20 +67,6 @@
             <name>topic_1</name>
             <dataType>HelloWorld</dataType>
         </topic>
-
-        <topic profile_name="topic2">
-            <name>topic_2</name>
-            <dataType>HelloWorld</dataType>
-        </topic>
-
-        <types>
-            <type>
-                <struct name="HelloWorld">
-                    <member name="index" type="uint32" />
-                    <member name="message" type="string" />
-                </struct>
-            </type>
-        </types>
 
     </profiles>
 </DS>

--- a/test/configuration/test_cases/test_26_backup_restore.xml
+++ b/test/configuration/test_cases/test_26_backup_restore.xml
@@ -2,7 +2,7 @@
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
     <!--
-        This test verifies that the backup server sends mathing PDP to its clients after
+        This test verifies that the backup server sends matching PDP to its clients after
         loading them from the backup file.
     -->
 

--- a/test/configuration/test_cases/test_26_backup_restore_1.xml
+++ b/test/configuration/test_cases/test_26_backup_restore_1.xml
@@ -12,7 +12,7 @@
     </clients>
 
     <snapshots file="./test_26_backup_restore_1.snapshot~">
-        <snapshot time="3">test_26_backup_restore_1_snapshot_server</snapshot>
+        <snapshot time="4">test_26_backup_restore_1_snapshot_server</snapshot>
     </snapshots>
 
     <profiles>
@@ -62,20 +62,6 @@
             <name>topic_1</name>
             <dataType>HelloWorld</dataType>
         </topic>
-
-        <topic profile_name="topic2">
-            <name>topic_2</name>
-            <dataType>HelloWorld</dataType>
-        </topic>
-
-        <types>
-            <type>
-                <struct name="HelloWorld">
-                    <member name="index" type="uint32" />
-                    <member name="message" type="string" />
-                </struct>
-            </type>
-        </types>
 
     </profiles>
 </DS>

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -1042,7 +1042,7 @@
                 "restore":
                 {
                     "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_26_backup_restore_1.xml",
-                    "creation_time": 4,
+                    "creation_time": 6,
                     "validation":
                     {
                         "count_lines_validation":


### PR DESCRIPTION
This PR updates the BACKUP tests, providing more time to let the server process a backup file and ping the corresponding clients.
It also remove the most basic tests from FAIL_TESTS to test the fix implemented in:

- https://github.com/eProsima/Fast-DDS/pull/4740