### PR TITLE
[21129] Migrate fastrtps namespace to fastdds

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The *Fast DDS* XML schema was duly updated to accommodate the new Discovery Serv
 
 -   The participant profile ``<builtin>`` tag contains a ``<discovery_config>`` tag where all discovery-related info is
     gathered. This new tag contains the following new XML child elements:
-	- ``<discoveryProtocol>``: specifies the discovery type through the ``DiscoveryProtocol_t`` enumeration.
+	- ``<discoveryProtocol>``: specifies the discovery type through the ``DiscoveryProtocol`` enumeration.
 	- ``<discoveryServersList>``: specifies the server or servers to which a Client/Server connects.
 	- ``<clientAnnouncementPeriod>``: specifies the time span between PDP metatraffic exchange.
 

--- a/examples/HelloWorldExampleDS/HelloWorldPubSubTypes.cxx
+++ b/examples/HelloWorldExampleDS/HelloWorldPubSubTypes.cxx
@@ -25,8 +25,8 @@
 #include "HelloWorldPubSubTypes.h"
 #include "HelloWorldCdrAux.hpp"
 
-using SerializedPayload_t = eprosima::fastrtps::rtps::SerializedPayload_t;
-using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+using SerializedPayload_t = eprosima::fastdds::rtps::SerializedPayload_t;
+using InstanceHandle_t = eprosima::fastdds::rtps::InstanceHandle_t;
 using DataRepresentationId_t = eprosima::fastdds::dds::DataRepresentationId_t;
 
 

--- a/examples/HelloWorldExampleDS/HelloWorldPubSubTypes.h
+++ b/examples/HelloWorldExampleDS/HelloWorldPubSubTypes.h
@@ -56,18 +56,18 @@ public:
 
     eProsima_user_DllExport bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload) override
+            eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool deserialize(
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
@@ -82,7 +82,7 @@ public:
 
     eProsima_user_DllExport bool getKey(
             void* data,
-            eprosima::fastrtps::rtps::InstanceHandle_t* ihandle,
+            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
     eProsima_user_DllExport void* createData() override;

--- a/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
@@ -94,7 +94,7 @@ bool HelloWorldPublisher::init(
         participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
     }
 
-    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
+    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::CLIENT;
     participant_qos.wire_protocol().participant_id = 2;
     participant_qos.wire_protocol().builtin.discovery_config.leaseDuration = eprosima::fastdds::c_TimeInfinite;
     participant_qos.name("Participant_pub");

--- a/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldPublisher.cpp
@@ -33,10 +33,8 @@
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/utils/IPLocator.h>
 
-using namespace eprosima::fastdds;
-using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::dds;
-using namespace eprosima::fastrtps::rtps;
+using namespace eprosima::fastdds::rtps;
 
 HelloWorldPublisher::HelloWorldPublisher()
     : mp_participant(nullptr)
@@ -98,7 +96,7 @@ bool HelloWorldPublisher::init(
 
     participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
     participant_qos.wire_protocol().participant_id = 2;
-    participant_qos.wire_protocol().builtin.discovery_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
+    participant_qos.wire_protocol().builtin.discovery_config.leaseDuration = eprosima::fastdds::c_TimeInfinite;
     participant_qos.name("Participant_pub");
 
     mp_participant = DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
@@ -115,7 +113,7 @@ bool HelloWorldPublisher::init(
     TopicQos topic_qos = TOPIC_QOS_DEFAULT;
 
     topic_qos.history().depth = 30;
-    topic_qos.history().kind = KEEP_LAST_HISTORY_QOS;
+    topic_qos.history().kind = eprosima::fastdds::KEEP_LAST_HISTORY_QOS;
     topic_qos.resource_limits().max_samples = 50;
     topic_qos.resource_limits().allocated_samples = 20;
 
@@ -124,7 +122,7 @@ bool HelloWorldPublisher::init(
 
     datawriter_qos.reliable_writer_qos().times.heartbeatPeriod.seconds = 2;
     datawriter_qos.reliable_writer_qos().times.heartbeatPeriod.nanosec = 0;
-    datawriter_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    datawriter_qos.reliability().kind = eprosima::fastdds::RELIABLE_RELIABILITY_QOS;
 
     mp_publisher = mp_participant->create_publisher(publisher_qos);
 

--- a/examples/HelloWorldExampleDS/HelloWorldServer.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldServer.cpp
@@ -42,7 +42,7 @@ bool HelloWorldServer::init(
 
     DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
 
-    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
+    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::SERVER;
     std::istringstream iss("44.49.53.43.53.45.52.56.45.52.5F.31");
     iss >> participant_qos.wire_protocol().prefix;
     participant_qos.wire_protocol().builtin.discovery_config.leaseDuration = c_TimeInfinite;

--- a/examples/HelloWorldExampleDS/HelloWorldServer.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldServer.cpp
@@ -28,9 +28,6 @@
 #include <fastdds/utils/IPLocator.h>
 
 using namespace eprosima::fastdds;
-using namespace eprosima::fastdds::rtps;
-
-using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::dds;
 using namespace eprosima::fastdds::rtps;
 
@@ -43,7 +40,7 @@ bool HelloWorldServer::init(
         Locator server_address)
 {
 
-    eprosima::fastdds::dds::DomainParticipantQos participant_qos = eprosima::fastdds::dds::PARTICIPANT_QOS_DEFAULT;
+    DomainParticipantQos participant_qos = PARTICIPANT_QOS_DEFAULT;
 
     participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::SERVER;
     std::istringstream iss("44.49.53.43.53.45.52.56.45.52.5F.31");

--- a/examples/HelloWorldExampleDS/HelloWorldServer.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldServer.cpp
@@ -27,8 +27,8 @@
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/utils/IPLocator.h>
 
-using namespace eprosima::fastrtps;
-using namespace eprosima::fastrtps::rtps;
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
 
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::dds;

--- a/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
@@ -32,8 +32,6 @@
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/utils/IPLocator.h>
 
-using namespace eprosima::fastdds;
-using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::dds;
 
@@ -94,7 +92,7 @@ bool HelloWorldSubscriber::init(
 
     participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
     participant_qos.wire_protocol().participant_id = 3;
-    participant_qos.wire_protocol().builtin.discovery_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
+    participant_qos.wire_protocol().builtin.discovery_config.leaseDuration = eprosima::fastdds::c_TimeInfinite;
     participant_qos.name("Participant_sub");
 
     mp_participant = DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
@@ -111,15 +109,15 @@ bool HelloWorldSubscriber::init(
     TopicQos topic_qos = TOPIC_QOS_DEFAULT;
 
     topic_qos.history().depth = 30;
-    topic_qos.history().kind = KEEP_LAST_HISTORY_QOS;
+    topic_qos.history().kind = eprosima::fastdds::KEEP_LAST_HISTORY_QOS;
     topic_qos.resource_limits().max_samples = 50;
     topic_qos.resource_limits().allocated_samples = 20;
 
     SubscriberQos subscriber_qos = SUBSCRIBER_QOS_DEFAULT;
     DataReaderQos datareader_qos = DATAREADER_QOS_DEFAULT;
 
-    datareader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    datareader_qos.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+    datareader_qos.reliability().kind = eprosima::fastdds::RELIABLE_RELIABILITY_QOS;
+    datareader_qos.durability().kind = eprosima::fastdds::TRANSIENT_LOCAL_DURABILITY_QOS;
 
     mp_subscriber = mp_participant->create_subscriber(subscriber_qos);
 

--- a/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorldSubscriber.cpp
@@ -90,7 +90,7 @@ bool HelloWorldSubscriber::init(
         participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
     }
 
-    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol_t::CLIENT;
+    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::CLIENT;
     participant_qos.wire_protocol().participant_id = 3;
     participant_qos.wire_protocol().builtin.discovery_config.leaseDuration = eprosima::fastdds::c_TimeInfinite;
     participant_qos.name("Participant_sub");

--- a/examples/HelloWorldExampleDS/HelloWorld_main.cpp
+++ b/examples/HelloWorldExampleDS/HelloWorld_main.cpp
@@ -115,7 +115,7 @@ const option::Descriptor usage[] = {
 /*static*/ const std::regex Arg::ipv4(R"(^((?:[0-9]{1,3}\.){3}[0-9]{1,3})?:?(?:(\d+))?$)");
 /*static*/ const std::regex Arg::ipv6(R"(^\[?((?:[0-9a-fA-F]{0,4}\:){7}[0-9a-fA-F]{0,4})?(?:\]:)?(?:(\d+))?$)");
 
-using namespace eprosima::fastrtps::rtps;
+using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::dds;
 
 int main(int argc, char** argv)

--- a/include/DiscoveryItem.h
+++ b/include/DiscoveryItem.h
@@ -34,7 +34,7 @@ class XMLDocument;
 namespace eprosima {
 namespace discovery_server {
 
-typedef fastrtps::rtps::GUID_t GUID_t;
+typedef fastdds::rtps::GUID_t GUID_t;
 
 //! common discovery info
 struct DiscoveryItem

--- a/include/DiscoveryServerManager.h
+++ b/include/DiscoveryServerManager.h
@@ -33,8 +33,6 @@
 #include "DiscoveryItem.h"
 
 using namespace eprosima::fastdds;
-using namespace eprosima::fastdds;
-using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::dds;
 
@@ -87,7 +85,7 @@ class DelayedParticipantCreation;
 class DelayedParticipantDestruction;
 
 class DiscoveryServerManager
-    : public eprosima::fastdds::dds::DomainParticipantListener // receive discovery callback information and
+    : public DomainParticipantListener // receive discovery callback information and
                                                                // subscriber lifeliness information
 
 {

--- a/include/DiscoveryServerManager.h
+++ b/include/DiscoveryServerManager.h
@@ -32,9 +32,9 @@
 
 #include "DiscoveryItem.h"
 
-using namespace eprosima::fastrtps;
 using namespace eprosima::fastdds;
-using namespace eprosima::fastrtps::rtps;
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::dds;
 
@@ -43,14 +43,14 @@ class XMLElement;
 } // namespace tinyxml2
 
 namespace eprosima {
-namespace fastrtps {
+namespace fastdds {
 namespace rtps {
 
 class PDP;
 class BuiltinProtocols;
 
 } // namespace rtps
-} // namespace fastrtps
+} // namespace fastdds
 
 namespace discovery_server {
 

--- a/include/LateJoiner.h
+++ b/include/LateJoiner.h
@@ -30,7 +30,7 @@
 namespace eprosima {
 namespace discovery_server {
 
-using eprosima::fastrtps::rtps::GUID_t;
+using eprosima::fastdds::rtps::GUID_t;
 
 class DelayedParticipantDestruction;
 

--- a/resources/static_types/HelloWorldPubSubTypes.cxx
+++ b/resources/static_types/HelloWorldPubSubTypes.cxx
@@ -25,8 +25,8 @@
 #include "HelloWorldPubSubTypes.h"
 #include "HelloWorldCdrAux.hpp"
 
-using SerializedPayload_t = eprosima::fastrtps::rtps::SerializedPayload_t;
-using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+using SerializedPayload_t = eprosima::fastdds::rtps::SerializedPayload_t;
+using InstanceHandle_t = eprosima::fastdds::rtps::InstanceHandle_t;
 using DataRepresentationId_t = eprosima::fastdds::dds::DataRepresentationId_t;
 
 

--- a/resources/static_types/HelloWorldPubSubTypes.h
+++ b/resources/static_types/HelloWorldPubSubTypes.h
@@ -56,18 +56,18 @@ public:
 
     eProsima_user_DllExport bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload) override
+            eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool deserialize(
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
@@ -82,7 +82,7 @@ public:
 
     eProsima_user_DllExport bool getKey(
             void* data,
-            eprosima::fastrtps::rtps::InstanceHandle_t* ihandle,
+            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
     eProsima_user_DllExport void* createData() override;

--- a/src/DiscoveryItem.cpp
+++ b/src/DiscoveryItem.cpp
@@ -31,7 +31,7 @@
                                                                  return a_eResult; }
 #endif // ifndef XMLCheckResult
 
-using namespace eprosima::fastrtps;
+using namespace eprosima::fastdds;
 using namespace eprosima::discovery_server;
 
 // basic discovery items operations
@@ -581,7 +581,7 @@ void DiscoveryItemDatabase::UpdateSubLiveliness(
 
     // Retrieve the participant that owns this subscriber
     GUID_t pguid(subs);
-    pguid.entityId = eprosima::fastrtps::rtps::c_EntityId_RTPSParticipant;
+    pguid.entityId = eprosima::fastdds::rtps::c_EntityId_RTPSParticipant;
 
     if (image.find(pguid) == image.end())
     {
@@ -962,8 +962,8 @@ void Snapshot::from_xml(
         tinyxml2::XMLElement* pRoot)
 {
     using namespace tinyxml2;
-    using eprosima::fastrtps::rtps::GuidPrefix_t;
-    using eprosima::fastrtps::rtps::EntityId_t;
+    using eprosima::fastdds::rtps::GuidPrefix_t;
+    using eprosima::fastdds::rtps::EntityId_t;
 
     if (pRoot != nullptr)
     {

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -30,8 +30,6 @@
 #include "log/DSLog.h"
 
 using namespace eprosima::fastdds;
-using namespace eprosima::fastdds;
-using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::rtps;
 using namespace eprosima::discovery_server;
 

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -29,15 +29,15 @@
 #include "LateJoiner.h"
 #include "log/DSLog.h"
 
-using namespace eprosima::fastrtps;
 using namespace eprosima::fastdds;
-using namespace eprosima::fastrtps::rtps;
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::rtps;
 using namespace eprosima::discovery_server;
 
 // non exported from Fast DDS (watch out they may be updated)
 namespace eprosima {
-namespace fastrtps {
+namespace fastdds {
 namespace DSxmlparser {
 const char* PROFILES = "profiles";
 const char* PROFILE_NAME = "profile_name";
@@ -50,7 +50,7 @@ const char* PUBLISHER = "publisher";
 const char* SUBSCRIBER = "subscriber";
 const char* TOPIC = "topic";
 } // namespace DSxmlparser
-} // namespace fastrtps
+} // namespace fastdds
 } // namespace eprosima
 
 /*static members*/
@@ -1402,7 +1402,7 @@ void DiscoveryServerManager::loadSubscriber(
     TopicAttributes topicAttr;
     if (topic_name != nullptr)
     {
-        if (!eprosima::fastrtps::rtps::RTPSDomain::get_topic_attributes_from_profile(std::string(
+        if (!eprosima::fastdds::rtps::RTPSDomain::get_topic_attributes_from_profile(std::string(
                     topic_name), topicAttr))
         {
             LOG_ERROR("DiscoveryServerManager::loadSubscriber couldn't load topic profile ");
@@ -1505,7 +1505,7 @@ void DiscoveryServerManager::loadPublisher(
     TopicAttributes topicAttr;
     if (topic_name != nullptr)
     {
-        if (!eprosima::fastrtps::rtps::RTPSDomain::get_topic_attributes_from_profile(std::string(
+        if (!eprosima::fastdds::rtps::RTPSDomain::get_topic_attributes_from_profile(std::string(
                     topic_name), topicAttr))
         {
             LOG_ERROR("DiscoveryServerManager::loadPublisher couldn't load topic profile ");

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -30,7 +30,6 @@
 #include "log/DSLog.h"
 
 using namespace eprosima::fastdds;
-using namespace eprosima::fastdds::rtps;
 using namespace eprosima::discovery_server;
 
 // non exported from Fast DDS (watch out they may be updated)
@@ -921,7 +920,7 @@ void DiscoveryServerManager::loadServer(
     // We define the PDP as external (when moved to fast library it would be SERVER)
     DiscoverySettings& b = dpQOS.wire_protocol().builtin.discovery_config;
     (void)b;
-    assert(b.discoveryProtocol == SERVER || b.discoveryProtocol == BACKUP);
+    assert(b.discoveryProtocol == eprosima::fastdds::rtps::DiscoveryProtocol::SERVER || b.discoveryProtocol == eprosima::fastdds::rtps::DiscoveryProtocol::BACKUP);
 
     // Create the participant or the associated events
     DelayedParticipantCreation event(creation_time, std::move(dpQOS), &DiscoveryServerManager::addServer);
@@ -1004,8 +1003,8 @@ void DiscoveryServerManager::loadClient(
 
     // we must assert that DiscoveryProtocol is CLIENT
 
-    if (dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::CLIENT &&
-            dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::SUPER_CLIENT)
+    if (dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::CLIENT &&
+            dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SUPER_CLIENT)
     {
         LOG_ERROR(
             "DiscoveryServerManager::loadClient try to create a client with an incompatible profile: " <<
@@ -1277,7 +1276,7 @@ void DiscoveryServerManager::loadSimple(
         }
 
         // we must assert that DiscoveryProtocol is CLIENT
-        if (dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol_t::SIMPLE)
+        if (dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SIMPLE)
         {
             LOG_ERROR(
                 "DiscoveryServerManager::loadSimple try to create a simple participant with an incompatible profile: " <<

--- a/src/LateJoiner.cpp
+++ b/src/LateJoiner.cpp
@@ -20,9 +20,8 @@
 #include "DiscoveryServerManager.h"
 
 using namespace eprosima::fastdds;
-using namespace eprosima::discovery_server;
-// New API
 using namespace eprosima::fastdds::dds;
+using namespace eprosima::discovery_server;
 
 // delayed creation of a new participant
 void DelayedParticipantCreation::operator ()(
@@ -31,8 +30,8 @@ void DelayedParticipantCreation::operator ()(
 
     DomainParticipant* p = DomainParticipantFactory::get_instance()->create_participant(0, qos, &manager);
 
-    fastdds::dds::Publisher* publisher_ = p->create_publisher(PUBLISHER_QOS_DEFAULT);
-    fastdds::dds::Subscriber* subscriber_ = p->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    Publisher* publisher_ = p->create_publisher(PUBLISHER_QOS_DEFAULT);
+    Subscriber* subscriber_ = p->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
 
     ParticipantCreatedEntityInfo info;
 
@@ -101,13 +100,13 @@ const LateJoinerDataTraits<DataWriter>::removeEndpoint LateJoinerDataTraits<Data
 
 /*static*/
 DataWriter* LateJoinerDataTraits<DataWriter>::createEndpoint(
-        fastdds::dds::DomainEntity* publisher,
+        DomainEntity* publisher,
         Topic* topic,
         const std::string& profile_name,
         void*)
 {
 
-    fastdds::dds::Publisher* pub = static_cast<fastdds::dds::Publisher*>(publisher);
+    Publisher* pub = static_cast<Publisher*>(publisher);
 
     if (profile_name.empty())
     {
@@ -129,12 +128,12 @@ const LateJoinerDataTraits<DataReader>::removeEndpoint LateJoinerDataTraits<Data
 
 /*static*/
 DataReader* LateJoinerDataTraits<DataReader>::createEndpoint(
-        fastdds::dds::DomainEntity* subscriber,
+        DomainEntity* subscriber,
         Topic* topic,
         const std::string& profile_name,
-        fastdds::dds::SubscriberListener* list /* = nullptr*/)
+        SubscriberListener* list /* = nullptr*/)
 {
-    fastdds::dds::Subscriber* sub = static_cast<fastdds::dds::Subscriber*>(subscriber);
+    Subscriber* sub = static_cast<Subscriber*>(subscriber);
 
     if (profile_name.empty())
     {

--- a/src/LateJoiner.cpp
+++ b/src/LateJoiner.cpp
@@ -19,7 +19,7 @@
 #include "log/DSLog.h"
 #include "DiscoveryServerManager.h"
 
-using namespace eprosima::fastrtps;
+using namespace eprosima::fastdds;
 using namespace eprosima::discovery_server;
 // New API
 using namespace eprosima::fastdds::dds;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,9 +24,9 @@
 #include "arguments.h"
 
 using namespace eprosima;
-using namespace fastrtps;
 using namespace fastdds;
-using namespace fastrtps::rtps;
+using namespace fastdds;
+using namespace fastdds::rtps;
 using namespace fastdds::rtps;
 using namespace discovery_server;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,6 @@
 
 using namespace eprosima;
 using namespace fastdds;
-using namespace fastdds;
-using namespace fastdds::rtps;
 using namespace fastdds::rtps;
 using namespace discovery_server;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR migrates fastrtps namespace to fastdds.
Related Fast DDS PR:
* https://github.com/eProsima/Fast-DDS/pull/4898
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
  - N/A The added tests pass locally.
- ❌ Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- N/A New feature has been documented/Current behavior is correctly described in the documentation.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
