### PR TITLE
[21230] Fix nightly job and move 2.6.x to weekly CI

### DIFF
--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -41,20 +41,14 @@ jobs:
       use-ccache: false
 
   nightly-ubuntu-ci-v1_2_1:
-    strategy:
-      fail-fast: false
-      matrix:
-        setup:
-          - os-version: 'ubuntu-22.04'
-            fastdds-branch: '2.10.x'
-          - os-version: 'ubuntu-20.04'
-            fastdds-branch: '2.6.x'
     uses: eProsima/Discovery-Server/.github/workflows/reusable-ubuntu-ci.yml@1.2.x
     with:
-      os-version: ${{ matrix.setup.os-version }}
-      label: 'nightly-ubuntu-ci-v1.2.1-${{ matrix.setup.fastdds-branch }}'
+      # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
+      # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
+      os-version: 'ubuntu-22.04'
+      label: 'nightly-ubuntu-ci-v1.2.1-2.10.x'
       discovery-server-branch: 'v1.2.1'
-      fastdds-branch: ${{ matrix.setup.fastdds-branch }}
+      fastdds-branch: '2.10.x'
       ctest-args: "-LE xfail"
       run-build: true
       run-tests: true

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: 'nightly-ubuntu-ci-master'
       discovery-server-branch: 'master'
       fastdds-branch: 'master'
@@ -31,7 +31,7 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: 'nightly-ubuntu-ci-v1.2.2-${{ matrix.fastdds-branch }}'
       discovery-server-branch: 'v1.2.2'
       fastdds-branch: ${{ matrix.fastdds-branch }}
@@ -45,13 +45,13 @@ jobs:
       fail-fast: false
       matrix:
         setup:
-          - os-image: 'ubuntu-22.04'
+          - os-version: 'ubuntu-22.04'
             fastdds-branch: '2.10.x'
-          - os-image: 'ubuntu-20.04'
+          - os-version: 'ubuntu-20.04'
             fastdds-branch: '2.6.x'
     uses: eProsima/Discovery-Server/.github/workflows/reusable-ubuntu-ci.yml@1.2.x
     with:
-      os-image: ${{ matrix.setup.os-image }}
+      os-version: ${{ matrix.setup.os-version }}
       label: 'nightly-ubuntu-ci-v1.2.1-${{ matrix.setup.fastdds-branch }}'
       discovery-server-branch: 'v1.2.1'
       fastdds-branch: ${{ matrix.setup.fastdds-branch }}

--- a/.github/workflows/weekly-ubuntu-ci.yml
+++ b/.github/workflows/weekly-ubuntu-ci.yml
@@ -1,0 +1,21 @@
+name: Fast DDS Discovery Server Ubuntu CI (weekly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * 1' # Run at minute 0 on Monday
+
+jobs:
+  weekly-ubuntu-ci-v1_2_1:
+    uses: eProsima/Discovery-Server/.github/workflows/reusable-ubuntu-ci.yml@1.2.x
+    with:
+      # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
+      # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
+      os-version: 'ubuntu-20.04'
+      label: 'weekly-ubuntu-ci-v1.2.1-2.6.x'
+      discovery-server-branch: 'v1.2.1'
+      fastdds-branch: '2.6.x'
+      ctest-args: "-LE xfail"
+      run-build: true
+      run-tests: true
+      use-ccache: false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
Nightly job was failing due to `os-image`-`os-version` name mismatched. 
This PR fixes it, and move `2.6.x` related job to weekly CI
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The added tests pass locally.
- **N/A** Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- N/A Check CI results: changes do not issue any warning.
- N/A Check CI results: failing tests are unrelated with the changes.
