### PR TITLE
[21244] Add utils script for type generation

### DIFF
--- a/utils/scripts/update_generated_code_from_idl.sh
+++ b/utils/scripts/update_generated_code_from_idl.sh
@@ -44,6 +44,17 @@ idl_files=(${idl_files[@]/$files_to_exclude})
 
 ret_value=0
 
+# CDR option check
+if [[ $1 == "CDRv1" ]]; then
+    cdr_arg="-cdr v1"
+elif [[ $1 == "CDRv2" ]]; then
+    cdr_arg="-cdr v2"
+elif [[ $1 == "CDRv1v2" ]]; then
+    cdr_arg="-cdr both"
+else
+    cdr_arg=""
+fi
+
 for idl_file in "${idl_files[@]}"; do
     idl_dir=$(dirname "$idl_file")
     file_from_gen=$(basename "$idl_file")
@@ -52,13 +63,8 @@ for idl_file in "${idl_files[@]}"; do
 
     cd "${idl_dir}"
 
-    # Detect if needs type_object.
-    [[ ${files_not_needing_typeobject[*]} =~ $idl_file ]] && to_arg='-no-typeobjectsupport' || to_arg=''
-
     # Detect if needs case sensitive.
     [[ ${files_needing_case_sensitive[*]} =~ $idl_file ]] && cs_arg='-cs' || cs_arg=''
-
-    [[ ${files_needing_no_typesupport[*]} =~ $idl_file ]] && nosupport_arg='-no-typesupport' || nosupport_arg=''
 
     # Detect if needs output directories.
     not_processed=true
@@ -68,14 +74,14 @@ for idl_file in "${idl_files[@]}"; do
             od_entry_split=(${od_entry//\|/ })
             for od_entry_split_element in ${od_entry_split[@]:1}; do
                 od_arg="-d ${od_entry_split_element}"
-                fastddsgen -replace -genapi $to_arg $cs_arg $od_arg "$file_from_gen" -no-dependencies
+                fastddsgen -replace $cdr_arg $cs_arg $od_arg "$file_from_gen"
             done
             break
         fi
     done
 
     if $not_processed ; then
-        fastddsgen -replace -genapi $to_arg $cs_arg $nosupport_arg "$file_from_gen" -no-dependencies
+        fastddsgen -replace $cdr_arg $cs_arg "$file_from_gen"
     fi
 
     if [[ $? != 0 ]]; then

--- a/utils/scripts/update_generated_code_from_idl.sh
+++ b/utils/scripts/update_generated_code_from_idl.sh
@@ -45,11 +45,11 @@ idl_files=(${idl_files[@]/$files_to_exclude})
 ret_value=0
 
 # CDR option check
-if [[ $1 == "CDRv1" ]]; then
+if [[ $1 == "cdr-v1" ]]; then
     cdr_arg="-cdr v1"
-elif [[ $1 == "CDRv2" ]]; then
+elif [[ $1 == "cdr-v2" ]]; then
     cdr_arg="-cdr v2"
-elif [[ $1 == "CDRv1v2" ]]; then
+elif [[ $1 == "cdr-both" ]]; then
     cdr_arg="-cdr both"
 else
     cdr_arg=""

--- a/utils/scripts/update_generated_code_from_idl.sh
+++ b/utils/scripts/update_generated_code_from_idl.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+files_to_exclude=(
+    )
+
+files_not_needing_typeobject=(
+    './examples/HelloWorldExampleDS/HelloWorld.idl'
+    './resources/static_types/HelloWorld.idl'
+    )
+
+files_needing_case_sensitive=(
+    )
+
+files_needing_output_dir=(
+    )
+
+files_needing_no_typesupport=(
+    )
+
+red='\E[1;31m'
+yellow='\E[1;33m'
+textreset='\E[1;0m'
+
+current_dir=$(git rev-parse --show-toplevel)
+
+if [[ ! "$(pwd -P)" -ef "$current_dir" ]]; then
+    echo -e "${red}This script must be executed in the repository root directory.${textreset}"
+    exit -1
+fi
+
+if [[ -z "$(which fastddsgen)" ]]; then
+    echo "Cannot find fastddsgen. Please, include it in PATH environment variable"
+    exit -1
+fi
+
+readarray -d '' idl_files < <(find . -iname \*.idl -print0)
+
+for del in ${files_to_exclude[@]}
+do
+    idl_files=("${idl_files[@]/$del}")
+done
+
+idl_files=(${idl_files[@]/$files_to_exclude})
+
+ret_value=0
+
+for idl_file in "${idl_files[@]}"; do
+    idl_dir=$(dirname "$idl_file")
+    file_from_gen=$(basename "$idl_file")
+
+    echo -e "Processing ${yellow}$idl_file${textreset}"
+
+    cd "${idl_dir}"
+
+    # Detect if needs type_object.
+    [[ ${files_not_needing_typeobject[*]} =~ $idl_file ]] && to_arg='-no-typeobjectsupport' || to_arg=''
+
+    # Detect if needs case sensitive.
+    [[ ${files_needing_case_sensitive[*]} =~ $idl_file ]] && cs_arg='-cs' || cs_arg=''
+
+    [[ ${files_needing_no_typesupport[*]} =~ $idl_file ]] && nosupport_arg='-no-typesupport' || nosupport_arg=''
+
+    # Detect if needs output directories.
+    not_processed=true
+    for od_entry in ${files_needing_output_dir[@]}; do
+        if [[ $od_entry = $idl_file\|* ]]; then
+            not_processed=false;
+            od_entry_split=(${od_entry//\|/ })
+            for od_entry_split_element in ${od_entry_split[@]:1}; do
+                od_arg="-d ${od_entry_split_element}"
+                fastddsgen -replace -genapi $to_arg $cs_arg $od_arg "$file_from_gen" -no-dependencies
+            done
+            break
+        fi
+    done
+
+    if $not_processed ; then
+        fastddsgen -replace -genapi $to_arg $cs_arg $nosupport_arg "$file_from_gen" -no-dependencies
+    fi
+
+    if [[ $? != 0 ]]; then
+        ret_value=-1
+    fi
+
+    cd -
+done
+
+exit $ret_value


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR performs a cherry pick to the commit in master that introduced the utils type generator.
It also introduces some changes (as the possibility to add an argument to the script for CDR generation, related with some CI refactor Fast DDS Gen PRS:)
- https://github.com/eProsima/Fast-DDS-Gen/pull/366
- https://github.com/eProsima/Fast-DDS-Gen/pull/367
- https://github.com/eProsima/Fast-DDS-Gen/pull/368
- https://github.com/eProsima/Fast-DDS-Gen/pull/369

Those PRs need to be updated with the corresponding CDR version:
- Fast DDS Gen 3.3.x (Fast DDS 2.14.x) -> `cdr-both`
- Fast DDS Gen 3.2.x (Fast DDS 2.13.x) -> `cdr-both`
- Fast DDS Gen 2.5.x (Fast DDS 2.10.x) -> `(no arg provided)`
- Fast DDS Gen 2.1.x (Fast DDS 2.6.x) -> `(no arg provided)`
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- **N/A** Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
