### PR TITLE
[21301] Remove `WriterProxyData` from public APIs

### DIFF
--- a/include/DiscoveryServerManager.h
+++ b/include/DiscoveryServerManager.h
@@ -289,7 +289,7 @@ public:
 
     void on_data_writer_discovery(
             DomainParticipant* participant,
-            rtps::WRITER_DISCOVERY_STATUS reason,
+            rtps::WriterDiscoveryStatus reason,
             const PublicationBuiltinTopicData& info,
             bool& should_be_ignored) override;
 
@@ -344,7 +344,7 @@ std::ostream& operator <<(
         ReaderDiscoveryInfo::DISCOVERY_STATUS);
 std::ostream& operator <<(
         std::ostream&,
-        WRITER_DISCOVERY_STATUS);
+        WriterDiscoveryStatus);
 
 } // namespace discovery_server
 } // namespace eprosima

--- a/include/DiscoveryServerManager.h
+++ b/include/DiscoveryServerManager.h
@@ -289,7 +289,8 @@ public:
 
     void on_data_writer_discovery(
             DomainParticipant* participant,
-            WriterDiscoveryInfo&& info,
+            rtps::WRITER_DISCOVERY_STATUS reason,
+            const PublicationBuiltinTopicData& info,
             bool& should_be_ignored) override;
 
     // callback liveliness functions
@@ -343,7 +344,7 @@ std::ostream& operator <<(
         ReaderDiscoveryInfo::DISCOVERY_STATUS);
 std::ostream& operator <<(
         std::ostream&,
-        WriterDiscoveryInfo::DISCOVERY_STATUS);
+        WRITER_DISCOVERY_STATUS);
 
 } // namespace discovery_server
 } // namespace eprosima

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -1722,12 +1722,12 @@ void DiscoveryServerManager::on_data_reader_discovery(
 
 void DiscoveryServerManager::on_data_writer_discovery(
         DomainParticipant* participant,
-        rtps::WRITER_DISCOVERY_STATUS reason,
+        rtps::WriterDiscoveryStatus reason,
         const PublicationBuiltinTopicData& info,
         bool& should_be_ignored)
 {
     should_be_ignored = false;
-    typedef WRITER_DISCOVERY_STATUS DS;
+    typedef WriterDiscoveryStatus DS;
 
     // if the callback origin was removed ignore
     GUID_t srcGuid = participant->guid();
@@ -1862,9 +1862,9 @@ std::ostream& eprosima::discovery_server::operator <<(
 
 std::ostream& eprosima::discovery_server::operator <<(
         std::ostream& o,
-        WRITER_DISCOVERY_STATUS s)
+        WriterDiscoveryStatus s)
 {
-    typedef WRITER_DISCOVERY_STATUS DS;
+    typedef WriterDiscoveryStatus DS;
 
     switch (s)
     {

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -18,11 +18,13 @@
 
 #include <tinyxml2.h>
 
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/rtps/RTPSDomain.hpp>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.hpp>
+#include <fastdds/rtps/writer/WriterDiscoveryInfo.hpp>
 
 #include "DiscoveryServerManager.h"
 #include "IDs.h"
@@ -1720,11 +1722,12 @@ void DiscoveryServerManager::on_data_reader_discovery(
 
 void DiscoveryServerManager::on_data_writer_discovery(
         DomainParticipant* participant,
-        WriterDiscoveryInfo&& info,
+        rtps::WRITER_DISCOVERY_STATUS reason,
+        const PublicationBuiltinTopicData& info,
         bool& should_be_ignored)
 {
-    static_cast<void>(should_be_ignored);
-    typedef WriterDiscoveryInfo::DISCOVERY_STATUS DS;
+    should_be_ignored = false;
+    typedef WRITER_DISCOVERY_STATUS DS;
 
     // if the callback origin was removed ignore
     GUID_t srcGuid = participant->guid();
@@ -1735,8 +1738,8 @@ void DiscoveryServerManager::on_data_writer_discovery(
         return;
     }
 
-    const GUID_t& pubsid = info.info.guid();
-    GUID_t partid = iHandle2GUID(info.info.RTPSParticipantKey());
+    const GUID_t& pubsid = info.guid;
+    GUID_t partid = info.participant_guid;
 
     // non reported info
     std::string part_name;
@@ -1781,7 +1784,7 @@ void DiscoveryServerManager::on_data_writer_discovery(
         part_name = ss.str();
     }
 
-    switch (info.status)
+    switch (reason)
     {
         case DS::DISCOVERED_WRITER:
 
@@ -1789,8 +1792,8 @@ void DiscoveryServerManager::on_data_writer_discovery(
                     srcName,
                     partid,
                     pubsid,
-                    info.info.typeName().to_string(),
-                    info.info.topicName().to_string(),
+                    info.type_name,
+                    info.topic_name,
                     callback_time);
             break;
         case DS::REMOVED_WRITER:
@@ -1802,8 +1805,8 @@ void DiscoveryServerManager::on_data_writer_discovery(
     }
 
     LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a publisher of participant "
-                            << part_name << " is " << info.status << " with typename: " << info.info.typeName()
-                            << " topic: " << info.info.topicName() << " GUID: " << pubsid);
+                            << part_name << " is " << reason << " with typename: " << info.type_name
+                            << " topic: " << info.topic_name << " GUID: " << pubsid);
 }
 
 void DiscoveryServerManager::on_liveliness_changed(
@@ -1859,9 +1862,9 @@ std::ostream& eprosima::discovery_server::operator <<(
 
 std::ostream& eprosima::discovery_server::operator <<(
         std::ostream& o,
-        WriterDiscoveryInfo::DISCOVERY_STATUS s)
+        WRITER_DISCOVERY_STATUS s)
 {
-    typedef WriterDiscoveryInfo::DISCOVERY_STATUS DS;
+    typedef WRITER_DISCOVERY_STATUS DS;
 
     switch (s)
     {

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -1792,8 +1792,8 @@ void DiscoveryServerManager::on_data_writer_discovery(
                     srcName,
                     partid,
                     pubsid,
-                    info.type_name,
-                    info.topic_name,
+                    info.type_name.to_string(),
+                    info.topic_name.to_string(),
                     callback_time);
             break;
         case DS::REMOVED_WRITER:

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -24,7 +24,7 @@
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.hpp>
-#include <fastdds/rtps/writer/WriterDiscoveryInfo.hpp>
+#include <fastdds/rtps/writer/WriterDiscoveryStatus.hpp>
 
 #include "DiscoveryServerManager.h"
 #include "IDs.h"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR updates the discovery callbacks to the changes introduced by https://github.com/eProsima/Fast-DDS/pull/5052
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- __NO__ Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
