### PR TITLE
[21310] Set Fast DDS 2.13.x as EOL

### DIFF
--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -21,20 +21,14 @@ jobs:
       use-ccache: false
 
   nightly-ubuntu-ci-v1_2_2:
-    strategy:
-      fail-fast: false
-      matrix:
-        fastdds-branch:
-         - '2.14.x'
-         - '2.13.x'
     uses: eProsima/Discovery-Server/.github/workflows/reusable-ubuntu-ci.yml@1.2.x
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
       os-version: 'ubuntu-22.04'
-      label: 'nightly-ubuntu-ci-v1.2.2-${{ matrix.fastdds-branch }}'
+      label: 'nightly-ubuntu-ci-v1.2.2-2.14.x'
       discovery-server-branch: 'v1.2.2'
-      fastdds-branch: ${{ matrix.fastdds-branch }}
+      fastdds-branch: '2.14.x'
       ctest-args: "-LE xfail"
       run-build: true
       run-tests: true

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -11,7 +11,6 @@ Please, refer to the [master branch](https://github.com/eProsima/Discovery-Serve
 |Fast DDS Version|Discovery Server Version|Discovery Server Latest Release|
 |----------------|------------------------|-------------------------------|
 |2.14|1.2.2|[v1.2.2](https://github.com/eProsima/Discovery-Server/releases/tag/v1.2.2)|
-|2.13|1.2.2|[v1.2.2](https://github.com/eProsima/Discovery-Server/releases/tag/v1.2.2)|
 |2.10|1.2.1|[v1.2.1](https://github.com/eProsima/Discovery-Server/releases/tag/v1.2.1)|
 |2.6|1.2.1|[v1.2.1](https://github.com/eProsima/Discovery-Server/releases/tag/v1.2.1)|
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR updates relase support document and CI jobs to set Fast DDS version 2.13.x as EOL
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The added tests pass locally.
- **N/A** Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- **N/A** Check CI results: changes do not issue any warning.
- **N/A** Check CI results: failing tests are unrelated with the changes.
