### PR TITLE
[21300] Remove `ReaderProxyData` from public APIs

### DIFF
--- a/include/DiscoveryServerManager.h
+++ b/include/DiscoveryServerManager.h
@@ -284,7 +284,8 @@ public:
 
     void on_data_reader_discovery(
             DomainParticipant* participant,
-            ReaderDiscoveryInfo&& info,
+            ReaderDiscoveryStatus reason,
+            const ReaderProxyData& info,
             bool& should_be_ignored) override;
 
     void on_data_writer_discovery(
@@ -341,7 +342,7 @@ std::ostream& operator <<(
         ParticipantDiscoveryInfo::DISCOVERY_STATUS);
 std::ostream& operator <<(
         std::ostream&,
-        ReaderDiscoveryInfo::DISCOVERY_STATUS);
+        ReaderDiscoveryStatus);
 std::ostream& operator <<(
         std::ostream&,
         WriterDiscoveryStatus);

--- a/include/DiscoveryServerManager.h
+++ b/include/DiscoveryServerManager.h
@@ -285,7 +285,7 @@ public:
     void on_data_reader_discovery(
             DomainParticipant* participant,
             ReaderDiscoveryStatus reason,
-            const ReaderProxyData& info,
+            const SubscriptionBuiltinTopicData& info,
             bool& should_be_ignored) override;
 
     void on_data_writer_discovery(

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -1641,11 +1641,12 @@ void DiscoveryServerManager::on_participant_discovery(
 
 void DiscoveryServerManager::on_data_reader_discovery(
         DomainParticipant* participant,
-        ReaderDiscoveryInfo&& info,
+        ReaderDiscoveryStatus reason,
+        const ReaderProxyData& info,
         bool& should_be_ignored)
 {
     static_cast<void>(should_be_ignored);
-    typedef ReaderDiscoveryInfo::DISCOVERY_STATUS DS;
+    typedef ReaderDiscoveryStatus DS;
 
     // if the callback origin was removed ignore
     GUID_t srcGuid = participant->guid();
@@ -1656,8 +1657,8 @@ void DiscoveryServerManager::on_data_reader_discovery(
         return;
     }
 
-    const GUID_t& subsid = info.info.guid();
-    GUID_t partid = iHandle2GUID(info.info.RTPSParticipantKey());
+    const GUID_t& subsid = info.guid();
+    GUID_t partid = iHandle2GUID(info.RTPSParticipantKey());
 
     // non reported info
     std::string part_name;
@@ -1702,11 +1703,11 @@ void DiscoveryServerManager::on_data_reader_discovery(
         part_name = ss.str();
     }
 
-    switch (info.status)
+    switch (reason)
     {
         case DS::DISCOVERED_READER:
-            state.AddDataReader(srcGuid, srcName, partid, subsid, info.info.typeName().to_string(),
-                    info.info.topicName().to_string(), callback_time);
+            state.AddDataReader(srcGuid, srcName, partid, subsid, info.typeName().to_string(),
+                    info.topicName().to_string(), callback_time);
             break;
         case DS::REMOVED_READER:
             state.RemoveDataReader(srcGuid, partid, subsid);
@@ -1716,8 +1717,8 @@ void DiscoveryServerManager::on_data_reader_discovery(
     }
 
     LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a subscriber of participant "
-                            << part_name << " is " << info.status << " with typename: " << info.info.typeName()
-                            << " topic: " << info.info.topicName() << " GUID: " << subsid);
+                            << part_name << " is " << reason << " with typename: " << info.typeName()
+                            << " topic: " << info.topicName() << " GUID: " << subsid);
 }
 
 void DiscoveryServerManager::on_data_writer_discovery(
@@ -1841,9 +1842,9 @@ std::ostream& eprosima::discovery_server::operator <<(
 
 std::ostream& eprosima::discovery_server::operator <<(
         std::ostream& o,
-        ReaderDiscoveryInfo::DISCOVERY_STATUS s)
+        ReaderDiscoveryStatus s)
 {
-    typedef ReaderDiscoveryInfo::DISCOVERY_STATUS DS;
+    typedef ReaderDiscoveryStatus DS;
 
     switch (s)
     {

--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -1642,7 +1642,7 @@ void DiscoveryServerManager::on_participant_discovery(
 void DiscoveryServerManager::on_data_reader_discovery(
         DomainParticipant* participant,
         ReaderDiscoveryStatus reason,
-        const ReaderProxyData& info,
+        const SubscriptionBuiltinTopicData& info,
         bool& should_be_ignored)
 {
     static_cast<void>(should_be_ignored);
@@ -1657,8 +1657,8 @@ void DiscoveryServerManager::on_data_reader_discovery(
         return;
     }
 
-    const GUID_t& subsid = info.guid();
-    GUID_t partid = iHandle2GUID(info.RTPSParticipantKey());
+    const GUID_t& subsid = info.guid;
+    GUID_t partid = info.participant_guid;
 
     // non reported info
     std::string part_name;
@@ -1706,8 +1706,8 @@ void DiscoveryServerManager::on_data_reader_discovery(
     switch (reason)
     {
         case DS::DISCOVERED_READER:
-            state.AddDataReader(srcGuid, srcName, partid, subsid, info.typeName().to_string(),
-                    info.topicName().to_string(), callback_time);
+            state.AddDataReader(srcGuid, srcName, partid, subsid, info.type_name.to_string(),
+                    info.topic_name.to_string(), callback_time);
             break;
         case DS::REMOVED_READER:
             state.RemoveDataReader(srcGuid, partid, subsid);
@@ -1717,8 +1717,8 @@ void DiscoveryServerManager::on_data_reader_discovery(
     }
 
     LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a subscriber of participant "
-                            << part_name << " is " << reason << " with typename: " << info.typeName()
-                            << " topic: " << info.topicName() << " GUID: " << subsid);
+                            << part_name << " is " << reason << " with typename: " << info.type_name
+                            << " topic: " << info.topic_name << " GUID: " << subsid);
 }
 
 void DiscoveryServerManager::on_data_writer_discovery(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates the discovery callbacks to the changes introduced by https://github.com/eProsima/Fast-DDS/pull/5078
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- __NO__ Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
