### PR TITLE
[22056] Transform locators using new host_id PID

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,7 @@ list(APPEND TEST_LIST
         test_60_disconnection
         test_61_superclient_environment_variable
 
+        test_94_tcpv4_custom_guid_transform_locators
         test_95_tcpv4_cli
         test_96_tcpv6_cli
         test_97_tcpv4_env_var

--- a/test/configuration/test_cases/test_94_tcpv4_custom_guid_transform_locators.xml
+++ b/test/configuration/test_cases/test_94_tcpv4_custom_guid_transform_locators.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- When a DS with a custom GUID (-i param of CLI) listens on any (0.0.0.0) and the clients use
+         localhost (127.0.0.1) to connect to the server, the GUID comparison is insufficient to
+         correctly transform the server's locator when it is received by the client. A more reliable
+         method is required to check if the server's locator is from the same host as the client.
+         This test is a regression from #22006.-->
+
+    <clients>
+        <client name="client1" profile_name="TCPv4_client_1" listening_port="0">
+            <subscriber topic="topic1"/>
+        </client>
+        <client name="client2" profile_name="TCPv4_client_2" listening_port="0">
+            <publisher topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_94_tcpv4_custom_guid_transform_locators.snapshot">
+        <snapshot time="5">Knows all</snapshot>
+    </snapshots>
+
+    <profiles>
+
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>transport_client_1</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+            <transport_descriptor>
+                <transport_id>transport_client_2</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="TCPv4_client_1" is_default_profile="true">
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>transport_client_1</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>42200</physical_port>
+                                    <port>42200</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="TCPv4_client_2" is_default_profile="true">
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>transport_client_2</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>42200</physical_port>
+                                    <port>42200</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+    </profiles>
+
+</DS>

--- a/test/configuration/test_cases/test_95_tcpv4_cli.xml
+++ b/test/configuration/test_cases/test_95_tcpv4_cli.xml
@@ -5,7 +5,7 @@
          we will use the whitelist to force the clients to send their locators
          with localhost. Otherwise, the server would not reuse the initial
          channel created and it might cause a failure in the connection,
-         depending of the value of the random logical port assigned.
+         depending on the value of the random logical port assigned.
          This could be avoided by using default GUIDs. -->
 
     <clients>

--- a/test/configuration/test_cases/test_96_tcpv6_cli.xml
+++ b/test/configuration/test_cases/test_96_tcpv6_cli.xml
@@ -5,7 +5,7 @@
          we will use the whitelist to force the clients to send their locators
          with localhost. Otherwise, the server would not reuse the initial
          channel created and it might cause a failure in the connection,
-         depending of the value of the random logical port assigned.
+         depending on the value of the random logical port assigned.
          This could be avoided by using default GUIDs. -->
 
     <clients>

--- a/test/configuration/test_cases/test_97_tcpv4_env_var.xml
+++ b/test/configuration/test_cases/test_97_tcpv4_env_var.xml
@@ -5,7 +5,7 @@
          we will use the whitelist to force the clients to send their locators
          with localhost. Otherwise, the server would not reuse the initial
          channel created and it might cause a failure in the connection,
-         depending of the value of the random logical port assigned.
+         depending on the value of the random logical port assigned.
          This could be avoided by using default GUIDs. -->
 
     <servers>

--- a/test/configuration/test_cases/test_98_tcpv6_env_var.xml
+++ b/test/configuration/test_cases/test_98_tcpv6_env_var.xml
@@ -5,7 +5,7 @@
          we will use the whitelist to force the clients to send their locators
          with localhost. Otherwise, the server would not reuse the initial
          channel created and it might cause a failure in the connection,
-         depending of the value of the random logical port assigned.
+         depending on the value of the random logical port assigned.
          This could be avoided by using default GUIDs. -->
 
     <servers>

--- a/test/configuration/test_solutions/test_94_tcpv4_custom_guid_transform_locators.snapshot
+++ b/test/configuration/test_solutions/test_94_tcpv4_custom_guid_transform_locators.snapshot
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1701424362042" process_time="5000" last_pdp_callback_time="620" last_edp_callback_time="1067" someone="true">
+        <description>Knows all</description>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Default Server number 0" discovered_timestamp="339"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="125">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="125"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="620">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="1067"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41" guid_entity="0.0.1.c1" server="false" alive="true" name="eProsima Default Server number 0" discovered_timestamp="489"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="615">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="1067"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="233">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="233"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -2547,6 +2547,64 @@
             }
         },
 
+        "test_94_tcpv4_custom_guid_transform_locators":
+        {
+            "description": [
+                "Test that a TCP discovery server with a custom GUID (-i CLI param) and listening on any (0.0.0.0)\n",
+                "is able to communicate with a client that connects to localhost (127.0.0.1).\n",
+                "This test is a regression from #22006"
+            ],
+
+            "processes":
+            {
+                "main":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_94_tcpv4_custom_guid_transform_locators.xml",
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_94_tcpv4_custom_guid_transform_locators.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": false,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_94_tcpv4_custom_guid_transform_locators.snapshot"
+                        }
+                    }
+                },
+                "fastddstool":
+                {
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "id" : 0,
+                        "tcp_address": "0.0.0.0",
+                        "tcp_port": 42200
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                }
+            }
+        },
+
         "test_95_tcpv4_cli":
         {
             "description": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR includes a test for a bug in which a TCP client connecting to `localhost` is unable to identify the locator of a TCP discovery server with a custom GUID listening on `any`.
Depends on: 

- https://github.com/eProsima/Fast-DDS/pull/5382

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 1.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The added tests pass locally.
- [X] Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation.
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
