### PR TITLE
[21793] Easy Mode Implementation - Tests

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install Python dependencies
         uses: eProsima/eProsima-CI/multiplatform/install_python_packages@v0
         with:
-          packages: vcstool xmlschema xmltodict==0.13.0 jsondiff==2.0.0 pandas==1.5.2
+          packages: vcstool xmlschema xmltodict==0.13.0 jsondiff==2.0.0 pandas==1.5.2 psutil
           upgrade: false
 
       - name: Setup CCache
@@ -185,7 +185,7 @@ jobs:
       - name: Install Python dependencies
         uses: eProsima/eProsima-CI/multiplatform/install_python_packages@v0
         with:
-          packages: vcstool xmlschema xmltodict==0.13.0 jsondiff==2.0.0 pandas==1.5.2
+          packages: vcstool xmlschema xmltodict==0.13.0 jsondiff==2.0.0 pandas==1.5.2 psutil
           upgrade: false
 
       - name: Setup CCache

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ list(APPEND TEST_LIST
         test_85_set_add_stop
         test_86_stop_all_servers
 
+        test_93_tcp_reconnect_with_clients
         test_94_tcpv4_custom_guid_transform_locators
         test_95_tcpv4_cli
         test_96_tcpv6_cli

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,6 +153,12 @@ set(TEST_CASE_LIST)
 set(FAIL_TEST_CASES)
 
 # For each test case, create different executables for each configuration
+find_program(FASTDDS_PYTHON_EXECUTABLE fastdds PATHS ${CMAKE_INSTALL_PREFIX}/bin)
+if(FASTDDS_PYTHON_EXECUTABLE)
+    message(STATUS "Found Fast DDS CLI executable at: ${FASTDDS_PYTHON_EXECUTABLE}")
+else()
+    message(WARNING "Fast DDS CLI Executable not found!")
+endif()
 foreach(TEST IN LISTS TEST_LIST)
 
     unset(TEST_NAME)
@@ -163,7 +169,7 @@ foreach(TEST IN LISTS TEST_LIST)
         COMMAND ${PYTHON_EXECUTABLE} ${RUN_TEST}
         -e $<TARGET_FILE:${PROJECT_NAME}>
         -p ${TESTS_PARAMS}
-        -f $<$<TARGET_EXISTS:fastdds::fast-discovery-server>:$<TARGET_FILE:fastdds::fast-discovery-server>>
+        -f ${FASTDDS_PYTHON_EXECUTABLE}
         -t ${TEST}
         -s true
         -i false) # Remove this argument to execute test with and without intraprocess
@@ -184,7 +190,7 @@ foreach(TEST IN LISTS TEST_LIST)
         COMMAND ${PYTHON_EXECUTABLE} ${RUN_TEST}
         -e $<TARGET_FILE:${PROJECT_NAME}>
         -p ${TESTS_PARAMS}
-        -f $<$<TARGET_EXISTS:fastdds::fast-discovery-server>:$<TARGET_FILE:fastdds::fast-discovery-server>>
+        -f ${FASTDDS_PYTHON_EXECUTABLE}
         -t ${TEST}
         -s false
         -i false) # Remove this argument to execute test with and without intraprocess

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,14 @@ list(APPEND TEST_LIST
         test_60_disconnection
         test_61_superclient_environment_variable
 
+        test_80_auto
+        test_81_auto_ros_domain_id_env_var
+        test_82_auto_ros_static_peers_env_var
+        test_83_start
+        test_84_add
+        test_85_set_add_stop
+        test_86_stop_all_servers
+
         test_94_tcpv4_custom_guid_transform_locators
         test_95_tcpv4_cli
         test_96_tcpv6_cli

--- a/test/configuration/test_cases/test_80_auto.xml
+++ b/test/configuration/test_cases/test_80_auto.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- S1 is created with Fast DDS CLI tool in AUTO mode.
+         Default domain is used (0).
+         Clients must know their matching participants:
+         S1: C1 & C2
+         C1: C2 & S1
+         C2: C1 & S1
+         Note that in AUTO mode all clients are Superclients-->
+
+    <simples>
+        <simple name="client1">
+            <publisher topic="topic1"/>
+        </simple>
+        <simple name="client2">
+            <subscriber topic="topic1"/>
+        </simple>
+    </simples>
+
+    <snapshots file="./test_80_auto.snapshot~">
+        <snapshot time="5">test_80_auto_snapshot</snapshot>
+    </snapshots>
+
+    <profiles>
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_80_auto.xml
+++ b/test/configuration/test_cases/test_80_auto.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- S1 is created with Fast DDS CLI tool in AUTO mode.
+    <!-- S1 is created with Fast DDS CLI tool in EASY_MODE.
          Default domain is used (0).
          Clients must know their matching participants:
          S1: C1 & C2
          C1: C2 & S1
          C2: C1 & S1
-         Note that in AUTO mode all clients are Superclients-->
+         Note that in EASY_MODE all clients are Superclients-->
 
     <simples>
         <simple name="client1">

--- a/test/configuration/test_cases/test_80_auto.xml
+++ b/test/configuration/test_cases/test_80_auto.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- S1 is created with Fast DDS CLI tool in EASY_MODE.
+    <!-- S1 is created with Fast DDS CLI tool in ROS2_EASY_MODE.
          Default domain is used (0).
          Clients must know their matching participants:
          S1: C1 & C2
          C1: C2 & S1
          C2: C1 & S1
-         Note that in EASY_MODE all clients are Superclients-->
+         Note that in ROS2_EASY_MODE all clients are Superclients-->
 
     <simples>
         <simple name="client1">

--- a/test/configuration/test_cases/test_81_auto_ros_domain_id_env_var.xml
+++ b/test/configuration/test_cases/test_81_auto_ros_domain_id_env_var.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- S1 is created with Fast DDS CLI tool in AUTO mode.
+    <!-- S1 is created with Fast DDS CLI tool in EASY_MODE.
          Domain ID is given to the tool using the environment variable.
          Clients must know their matching participants:
          S1: C1 & C2
          C1: C2 & S1
          C2: C1 & S1
-         Note that in AUTO mode all clients are Superclients-->
+         Note that in EASY_MODE all clients are Superclients-->
 
     <simples>
         <simple name="client1">

--- a/test/configuration/test_cases/test_81_auto_ros_domain_id_env_var.xml
+++ b/test/configuration/test_cases/test_81_auto_ros_domain_id_env_var.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- S1 is created with Fast DDS CLI tool in AUTO mode.
+         Domain ID is given to the tool using the environment variable.
+         Clients must know their matching participants:
+         S1: C1 & C2
+         C1: C2 & S1
+         C2: C1 & S1
+         Note that in AUTO mode all clients are Superclients-->
+
+    <simples>
+        <simple name="client1">
+            <publisher topic="topic1"/>
+        </simple>
+        <simple name="client2">
+            <subscriber topic="topic1"/>
+        </simple>
+    </simples>
+
+    <snapshots file="./test_81_auto_ros_domain_id_env_var.snapshot~">
+        <snapshot time="5">test_81_auto_ros_domain_id_env_var</snapshot>
+    </snapshots>
+
+    <profiles>
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_81_auto_ros_domain_id_env_var.xml
+++ b/test/configuration/test_cases/test_81_auto_ros_domain_id_env_var.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- S1 is created with Fast DDS CLI tool in EASY_MODE.
+    <!-- S1 is created with Fast DDS CLI tool in ROS2_EASY_MODE.
          Domain ID is given to the tool using the environment variable.
          Clients must know their matching participants:
          S1: C1 & C2
          C1: C2 & S1
          C2: C1 & S1
-         Note that in EASY_MODE all clients are Superclients-->
+         Note that in ROS2_EASY_MODE all clients are Superclients-->
 
     <simples>
         <simple name="client1">

--- a/test/configuration/test_cases/test_82_auto_ros_static_peers_env_var.xml
+++ b/test/configuration/test_cases/test_82_auto_ros_static_peers_env_var.xml
@@ -24,33 +24,18 @@
     </snapshots>
 
     <profiles>
-        <transport_descriptors>
-            <transport_descriptor>
-                <transport_id>generic_tcp_transport</transport_id>
-                <type>TCPv4</type>
-                <listening_ports>
-                    <port>0</port>
-                </listening_ports>
-            </transport_descriptor>
-        </transport_descriptors>
-
         <participant profile_name="client1_S1" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>7402</physical_port>
                                     <port>7402</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
@@ -66,20 +51,15 @@
         <participant profile_name="client1_S2" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>8152</physical_port>
                                     <port>8152</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>

--- a/test/configuration/test_cases/test_82_auto_ros_static_peers_env_var.xml
+++ b/test/configuration/test_cases/test_82_auto_ros_static_peers_env_var.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- Servers are created with Fast DDS CLI tool in AUTO mode.
+         S2 uses the ROS_STATIC_PEERS environment variable to point to S1.
+         Clients must know their matching participants:
+         S1: C1 & S2
+         S2: C2 & S1
+         C1: C2 & S1
+         C2: C1 & S2
+         Note that in AUTO mode all clients are Superclients-->
+
+    <clients>
+        <client name="client1_S1" profile_name="client1_S1" listening_port="0">
+            <publisher topic="topic1"/>
+        </client>
+        <client name="client1_S2" profile_name="client1_S2" listening_port="0">
+            <subscriber topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_82_auto_ros_static_peers_env_var.snapshot~">
+        <snapshot time="5">test_82_auto_ros_static_peers_env_var</snapshot>
+    </snapshots>
+
+    <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>generic_tcp_transport</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="client1_S1" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>7402</physical_port>
+                                    <port>7402</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="client1_S2" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>8152</physical_port>
+                                    <port>8152</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_82_auto_ros_static_peers_env_var.xml
+++ b/test/configuration/test_cases/test_82_auto_ros_static_peers_env_var.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Servers are created with Fast DDS CLI tool in EASY_MODE.
+    <!-- Servers are created with Fast DDS CLI tool in ROS2_EASY_MODE.
          S2 uses the ROS_STATIC_PEERS environment variable to point to S1.
          Clients must know their matching participants:
          S1: C1 & S2
          S2: C2 & S1
          C1: C2 & S1
          C2: C1 & S2
-         Note that in EASY_MODE all clients are Superclients-->
+         Note that in ROS2_EASY_MODE all clients are Superclients-->
 
     <clients>
         <client name="client1_S1" profile_name="client1_S1" listening_port="0">

--- a/test/configuration/test_cases/test_82_auto_ros_static_peers_env_var.xml
+++ b/test/configuration/test_cases/test_82_auto_ros_static_peers_env_var.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Servers are created with Fast DDS CLI tool in AUTO mode.
+    <!-- Servers are created with Fast DDS CLI tool in EASY_MODE.
          S2 uses the ROS_STATIC_PEERS environment variable to point to S1.
          Clients must know their matching participants:
          S1: C1 & S2
          S2: C2 & S1
          C1: C2 & S1
          C2: C1 & S2
-         Note that in AUTO mode all clients are Superclients-->
+         Note that in EASY_MODE all clients are Superclients-->
 
     <clients>
         <client name="client1_S1" profile_name="client1_S1" listening_port="0">

--- a/test/configuration/test_cases/test_83_start.xml
+++ b/test/configuration/test_cases/test_83_start.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- S1 is created with Fast DDS CLI tool in EASY_MODE.
+    <!-- S1 is created with Fast DDS CLI tool in ROS2_EASY_MODE.
          S2 is created using the START keyword to point to S1.
          Clients must know their matching participants:
          S1: C1 & S2
          S2: C2 & S1
          C1: C2 & S1
          C2: C1 & S2
-         Note that in EASY_MODE all clients are Superclients-->
+         Note that in ROS2_EASY_MODE all clients are Superclients-->
 
     <clients>
         <client name="client1_S1" profile_name="client1_S1" listening_port="0">

--- a/test/configuration/test_cases/test_83_start.xml
+++ b/test/configuration/test_cases/test_83_start.xml
@@ -24,33 +24,18 @@
     </snapshots>
 
     <profiles>
-        <transport_descriptors>
-            <transport_descriptor>
-                <transport_id>generic_tcp_transport</transport_id>
-                <type>TCPv4</type>
-                <listening_ports>
-                    <port>0</port>
-                </listening_ports>
-            </transport_descriptor>
-        </transport_descriptors>
-
         <participant profile_name="client1_S1" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>7402</physical_port>
                                     <port>7402</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
@@ -66,20 +51,15 @@
         <participant profile_name="client1_S2" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>8152</physical_port>
                                     <port>8152</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>

--- a/test/configuration/test_cases/test_83_start.xml
+++ b/test/configuration/test_cases/test_83_start.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- S1 is created with Fast DDS CLI tool in AUTO mode.
+    <!-- S1 is created with Fast DDS CLI tool in EASY_MODE.
          S2 is created using the START keyword to point to S1.
          Clients must know their matching participants:
          S1: C1 & S2
          S2: C2 & S1
          C1: C2 & S1
          C2: C1 & S2
-         Note that in AUTO mode all clients are Superclients-->
+         Note that in EASY_MODE all clients are Superclients-->
 
     <clients>
         <client name="client1_S1" profile_name="client1_S1" listening_port="0">

--- a/test/configuration/test_cases/test_83_start.xml
+++ b/test/configuration/test_cases/test_83_start.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- S1 is created with Fast DDS CLI tool in AUTO mode.
+         S2 is created using the START keyword to point to S1.
+         Clients must know their matching participants:
+         S1: C1 & S2
+         S2: C2 & S1
+         C1: C2 & S1
+         C2: C1 & S2
+         Note that in AUTO mode all clients are Superclients-->
+
+    <clients>
+        <client name="client1_S1" profile_name="client1_S1" listening_port="0">
+            <publisher topic="topic1"/>
+        </client>
+        <client name="client1_S2" profile_name="client1_S2" listening_port="0">
+            <subscriber topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_83_start.snapshot~">
+        <snapshot time="5">test_83_start</snapshot>
+    </snapshots>
+
+    <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>generic_tcp_transport</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="client1_S1" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>7402</physical_port>
+                                    <port>7402</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="client1_S2" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>8152</physical_port>
+                                    <port>8152</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_84_add.xml
+++ b/test/configuration/test_cases/test_84_add.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Servers are created with Fast DDS CLI tool in AUTO mode.
+    <!-- Servers are created with Fast DDS CLI tool in EASY_MODE.
          Then, the Fast DDS CLI tool is called with the ADD keyword to make S2 point to S1.
          Clients must know their matching participants:
          S1: C1 & S2
          S2: C2 & S1
          C1: C2 & S1
          C2: C1 & S2
-         Note that in AUTO mode all clients are Superclients-->
+         Note that in EASY_MODE all clients are Superclients-->
 
     <clients>
         <client name="client1_S1" profile_name="client1_S1" listening_port="0">

--- a/test/configuration/test_cases/test_84_add.xml
+++ b/test/configuration/test_cases/test_84_add.xml
@@ -24,33 +24,18 @@
     </snapshots>
 
     <profiles>
-        <transport_descriptors>
-            <transport_descriptor>
-                <transport_id>generic_tcp_transport</transport_id>
-                <type>TCPv4</type>
-                <listening_ports>
-                    <port>0</port>
-                </listening_ports>
-            </transport_descriptor>
-        </transport_descriptors>
-
         <participant profile_name="client1_S1" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>7402</physical_port>
                                     <port>7402</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
@@ -66,20 +51,15 @@
         <participant profile_name="client1_S2" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>8152</physical_port>
                                     <port>8152</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>

--- a/test/configuration/test_cases/test_84_add.xml
+++ b/test/configuration/test_cases/test_84_add.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- Servers are created with Fast DDS CLI tool in AUTO mode.
+         Then, the Fast DDS CLI tool is called with the ADD keyword to make S2 point to S1.
+         Clients must know their matching participants:
+         S1: C1 & S2
+         S2: C2 & S1
+         C1: C2 & S1
+         C2: C1 & S2
+         Note that in AUTO mode all clients are Superclients-->
+
+    <clients>
+        <client name="client1_S1" profile_name="client1_S1" listening_port="0">
+            <publisher topic="topic1"/>
+        </client>
+        <client name="client1_S2" profile_name="client1_S2" listening_port="0">
+            <subscriber topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_84_add.snapshot~">
+        <snapshot time="5">test_84_add</snapshot>
+    </snapshots>
+
+    <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>generic_tcp_transport</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="client1_S1" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>7402</physical_port>
+                                    <port>7402</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="client1_S2" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>8152</physical_port>
+                                    <port>8152</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_84_add.xml
+++ b/test/configuration/test_cases/test_84_add.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Servers are created with Fast DDS CLI tool in EASY_MODE.
+    <!-- Servers are created with Fast DDS CLI tool in ROS2_EASY_MODE.
          Then, the Fast DDS CLI tool is called with the ADD keyword to make S2 point to S1.
          Clients must know their matching participants:
          S1: C1 & S2
          S2: C2 & S1
          C1: C2 & S1
          C2: C1 & S2
-         Note that in EASY_MODE all clients are Superclients-->
+         Note that in ROS2_EASY_MODE all clients are Superclients-->
 
     <clients>
         <client name="client1_S1" profile_name="client1_S1" listening_port="0">

--- a/test/configuration/test_cases/test_85_set_add_stop.xml
+++ b/test/configuration/test_cases/test_85_set_add_stop.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Servers are created with Fast DDS CLI tool in EASY_MODE.
+    <!-- Servers are created with Fast DDS CLI tool in ROS2_EASY_MODE.
          Clients must know their matching participants:
          Snapshot 1 (All_isolated):
             S1: C1  |  C1: S1
@@ -27,7 +27,7 @@
             S3: C3       |  C3: S3 & C1 & C2
             S4: C4 & S2  |  C4: S4 & C2
 
-         Note that in EASY_MODE all clients are Superclients-->
+         Note that in ROS2_EASY_MODE all clients are Superclients-->
 
     <clients>
         <client name="client1_S1" profile_name="client1_S1" listening_port="0">

--- a/test/configuration/test_cases/test_85_set_add_stop.xml
+++ b/test/configuration/test_cases/test_85_set_add_stop.xml
@@ -8,7 +8,7 @@
             S2: C2  |  C2: S2
             S3: C3  |  C3: S3
             S4: C4  |  C4: S4
-         - Fast DDS CLI tool is called with the ADD keyword to make S2 point to S1.
+         - Fast DDS CLI tool is called with the ADD keyword to make S2 point to S1 and S3.
          Snapshot 2 (S4_isolated):
             S1: C1 & S2 & S3  |  C1: S1 & C2 & C3
             S2: C2 & S1 & S3  |  C2: S2 & C1 & C3
@@ -50,9 +50,9 @@
 
     <snapshots file="./test_85_set_add_stop.snapshot~">
         <snapshot time="3">All_isolated</snapshot>
-        <snapshot time="8">S4_isolated</snapshot>
-        <snapshot time="14">S1_S3_isolated_from_S2_S4</snapshot>
-        <snapshot time="19">S1_stopped</snapshot>
+        <snapshot time="17">S4_isolated</snapshot>
+        <snapshot time="29">S1_S3_isolated_from_S2_S4</snapshot>
+        <snapshot time="42">S1_stopped</snapshot>
     </snapshots>
 
     <profiles>
@@ -88,8 +88,6 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
             </rtps>
@@ -117,8 +115,6 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
             </rtps>
@@ -146,8 +142,6 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
             </rtps>
@@ -175,8 +169,6 @@
                         <initialAnnouncements>
                             <count>0</count>
                         </initialAnnouncements>
-                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
-                        <leaseDuration>DURATION_INFINITY</leaseDuration>
                     </discovery_config>
                 </builtin>
             </rtps>

--- a/test/configuration/test_cases/test_85_set_add_stop.xml
+++ b/test/configuration/test_cases/test_85_set_add_stop.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Servers are created with Fast DDS CLI tool in AUTO mode.
+    <!-- Servers are created with Fast DDS CLI tool in EASY_MODE.
          Clients must know their matching participants:
          Snapshot 1 (All_isolated):
             S1: C1  |  C1: S1
@@ -27,7 +27,7 @@
             S3: C3       |  C3: S3 & C1 & C2
             S4: C4 & S2  |  C4: S4 & C2
 
-         Note that in AUTO mode all clients are Superclients-->
+         Note that in EASY_MODE all clients are Superclients-->
 
     <clients>
         <client name="client1_S1" profile_name="client1_S1" listening_port="0">

--- a/test/configuration/test_cases/test_85_set_add_stop.xml
+++ b/test/configuration/test_cases/test_85_set_add_stop.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- Servers are created with Fast DDS CLI tool in AUTO mode.
+         Clients must know their matching participants:
+         Snapshot 1 (All_isolated):
+            S1: C1  |  C1: S1
+            S2: C2  |  C2: S2
+            S3: C3  |  C3: S3
+            S4: C4  |  C4: S4
+         - Fast DDS CLI tool is called with the ADD keyword to make S2 point to S1.
+         Snapshot 2 (S4_isolated):
+            S1: C1 & S2 & S3  |  C1: S1 & C2 & C3
+            S2: C2 & S1 & S3  |  C2: S2 & C1 & C3
+            S3: C3 & S1 & S2  |  C3: S3 & C1 & C2
+            S4: C4            |  C4: S4
+         - Fast DDS CLI tool is called with the SET keyword to make S2 point only to S4.
+         Snapshot 3 (S1_S3_isolated_from_S2_S4):
+            S1: C1 & S3  |  C1: S1 & C2 & C3
+            S2: C2 & S4  |  C2: S2 & C1 & C3 & C4
+            S3: C3 & S1  |  C3: S3 & C1 & C2
+            S4: C4 & S2  |  C4: S4 & C2
+         - Fast DDS CLI tool is called with the STOP keyword to stop S1.
+         Snapshot 4 (S1_stopped):
+            ***********  |  C1: C2 & C3
+            S2: C2 & S4  |  C2: S2 & C1 & C3 & C4
+            S3: C3       |  C3: S3 & C1 & C2
+            S4: C4 & S2  |  C4: S4 & C2
+
+         Note that in AUTO mode all clients are Superclients-->
+
+    <clients>
+        <client name="client1_S1" profile_name="client1_S1" listening_port="0">
+            <publisher topic="topic1"/>
+            <subscriber topic="topic1"/>
+        </client>
+        <client name="client1_S2" profile_name="client1_S2" listening_port="0">
+            <publisher topic="topic1"/>
+            <subscriber topic="topic1"/>
+        </client>
+        <client name="client1_S3" profile_name="client1_S3" listening_port="0">
+            <publisher topic="topic1"/>
+            <subscriber topic="topic1"/>
+        </client>
+        <client name="client1_S4" profile_name="client1_S4" listening_port="0">
+            <publisher topic="topic1"/>
+            <subscriber topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_85_set_add_stop.snapshot~">
+        <snapshot time="3">All_isolated</snapshot>
+        <snapshot time="8">S4_isolated</snapshot>
+        <snapshot time="14">S1_S3_isolated_from_S2_S4</snapshot>
+        <snapshot time="19">S1_stopped</snapshot>
+    </snapshots>
+
+    <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>generic_tcp_transport</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="client1_S1" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>7652</physical_port>
+                                    <port>7652</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="client1_S2" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>7902</physical_port>
+                                    <port>7902</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="client1_S3" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.33.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>8152</physical_port>
+                                    <port>8152</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="client1_S4" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.34.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>8402</physical_port>
+                                    <port>8402</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_85_set_add_stop.xml
+++ b/test/configuration/test_cases/test_85_set_add_stop.xml
@@ -56,33 +56,18 @@
     </snapshots>
 
     <profiles>
-        <transport_descriptors>
-            <transport_descriptor>
-                <transport_id>generic_tcp_transport</transport_id>
-                <type>TCPv4</type>
-                <listening_ports>
-                    <port>0</port>
-                </listening_ports>
-            </transport_descriptor>
-        </transport_descriptors>
-
         <participant profile_name="client1_S1" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>7652</physical_port>
                                     <port>7652</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
@@ -96,20 +81,15 @@
         <participant profile_name="client1_S2" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>7902</physical_port>
                                     <port>7902</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
@@ -123,20 +103,15 @@
         <participant profile_name="client1_S3" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.33.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>8152</physical_port>
                                     <port>8152</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
@@ -150,20 +125,15 @@
         <participant profile_name="client1_S4" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.34.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>8402</physical_port>
                                     <port>8402</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>

--- a/test/configuration/test_cases/test_86_stop_all_servers.xml
+++ b/test/configuration/test_cases/test_86_stop_all_servers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Servers are created with Fast DDS CLI tool in EASY_MODE.
+    <!-- Servers are created with Fast DDS CLI tool in ROS2_EASY_MODE.
          Clients must know their matching participants:
          Snapshot 1 (Each client know its server):
             S1: C1  |  C1: S1

--- a/test/configuration/test_cases/test_86_stop_all_servers.xml
+++ b/test/configuration/test_cases/test_86_stop_all_servers.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- Servers are created with Fast DDS CLI tool in AUTO mode.
+         Clients must know their matching participants:
+         Snapshot 1 (Each client know its server):
+            S1: C1  |  C1: S1
+            S2: C2  |  C2: S2
+            S3: C3  |  C3: S3
+         - Fast DDS CLI tool is called with the STOP keyword and 'all' argument.
+         Snapshot 2 (Servers down):
+            ******* |  C1: -
+            ******* |  C2: -
+            ******* |  C3: -  -->
+
+    <clients>
+        <client name="client1_S1" profile_name="client1_S1" listening_port="0">
+            <subscriber topic="topic1"/>
+        </client>
+        <client name="client1_S2" profile_name="client1_S2" listening_port="0">
+            <subscriber topic="topic1"/>
+        </client>
+        <client name="client1_S3" profile_name="client1_S3" listening_port="0">
+            <subscriber topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_85_set_add_stop.snapshot~">
+        <snapshot time="3">Servers_up</snapshot>
+        <snapshot time="7">Servers_down</snapshot>
+    </snapshots>
+
+    <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>generic_tcp_transport</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="client1_S1" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>7652</physical_port>
+                                    <port>7652</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="client1_S2" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>7902</physical_port>
+                                    <port>7902</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="client1_S3" >
+            <rtps>
+                <prefix>63.6c.69.65.6e.74.33.5f.73.31.5f.5f</prefix>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>generic_tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>8152</physical_port>
+                                    <port>8152</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_86_stop_all_servers.xml
+++ b/test/configuration/test_cases/test_86_stop_all_servers.xml
@@ -31,33 +31,18 @@
     </snapshots>
 
     <profiles>
-        <transport_descriptors>
-            <transport_descriptor>
-                <transport_id>generic_tcp_transport</transport_id>
-                <type>TCPv4</type>
-                <listening_ports>
-                    <port>0</port>
-                </listening_ports>
-            </transport_descriptor>
-        </transport_descriptors>
-
         <participant profile_name="client1_S1" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>7652</physical_port>
                                     <port>7652</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
@@ -73,20 +58,15 @@
         <participant profile_name="client1_S2" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>7902</physical_port>
                                     <port>7902</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>
@@ -102,20 +82,15 @@
         <participant profile_name="client1_S3" >
             <rtps>
                 <prefix>63.6c.69.65.6e.74.33.5f.73.31.5f.5f</prefix>
-                <useBuiltinTransports>false</useBuiltinTransports>
-                <userTransports>
-                    <transport_id>generic_tcp_transport</transport_id>
-                </userTransports>
                 <builtin>
                     <discovery_config>
                         <discoveryProtocol>CLIENT</discoveryProtocol>
                         <discoveryServersList>
                             <locator>
-                                <tcpv4>
+                                <udpv4>
                                     <address>127.0.0.1</address>
-                                    <physical_port>8152</physical_port>
                                     <port>8152</port>
-                                </tcpv4>
+                                </udpv4>
                             </locator>
                         </discoveryServersList>
                         <initialAnnouncements>

--- a/test/configuration/test_cases/test_86_stop_all_servers.xml
+++ b/test/configuration/test_cases/test_86_stop_all_servers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
 
-    <!-- Servers are created with Fast DDS CLI tool in AUTO mode.
+    <!-- Servers are created with Fast DDS CLI tool in EASY_MODE.
          Clients must know their matching participants:
          Snapshot 1 (Each client know its server):
             S1: C1  |  C1: S1

--- a/test/configuration/test_cases/test_93_tcp_reconnect_with_clients_A.xml
+++ b/test/configuration/test_cases/test_93_tcp_reconnect_with_clients_A.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <servers>
+        <server name="server" profile_name="TCP_server_A"/>
+    </servers>
+
+    <clients>
+        <client name="client1" profile_name="TCP_client1_serverA" listening_port="0">
+            <publisher topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_93_tcp_reconnect_with_clients_A.snapshot~">
+        <snapshot time="5">Knows server B, client A and client B</snapshot>
+        <snapshot time="15">Do not know server B</snapshot>
+        <snapshot time="21">Knows server B, client A and client B</snapshot>
+    </snapshots>
+
+    <profiles>
+
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>tcp_server</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>41811</port>
+                </listening_ports>
+            </transport_descriptor>
+            <transport_descriptor>
+                <transport_id>tcp_generic</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="TCP_client1_serverA" >
+            <rtps>
+                <userTransports>
+                    <transport_id>tcp_generic</transport_id>
+                </userTransports>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <prefix>63.6c.69.65.6e.74.31.5f.73.31.5f.5f</prefix>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>41811</physical_port>
+                                    <port>41811</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="TCP_server_A">
+            <rtps>
+                <userTransports>
+                    <transport_id>tcp_server</transport_id>
+                </userTransports>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <prefix>44.49.53.43.53.45.52.56.45.52.5F.31</prefix>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>SERVER</discoveryProtocol>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                    <metatrafficUnicastLocatorList>
+                        <locator>
+                            <tcpv4>
+                                <address>127.0.0.1</address>
+                                <physical_port>41811</physical_port>
+                                <port>41811</port>
+                            </tcpv4>
+                        </locator>
+                    </metatrafficUnicastLocatorList>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_93_tcp_reconnect_with_clients_B.xml
+++ b/test/configuration/test_cases/test_93_tcp_reconnect_with_clients_B.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <servers>
+        <server name="server" profile_name="TCP_server_B"/>
+    </servers>
+
+    <clients>
+        <client name="client1" profile_name="TCP_client1_serverB" listening_port="0">
+            <subscriber topic="topic1"/>
+        </client>
+    </clients>
+
+    <snapshots file="./test_93_tcp_reconnect_with_clients_B.snapshot~">
+        <snapshot time="5">Knows server A, client A and client B</snapshot>
+        <snapshot time="10">Do not know server A</snapshot>
+    </snapshots>
+
+    <profiles>
+
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>tcp_server</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>41812</port>
+                </listening_ports>
+            </transport_descriptor>
+            <transport_descriptor>
+                <transport_id>tcp_generic</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>0</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="TCP_client1_serverB" >
+            <rtps>
+                <userTransports>
+                    <transport_id>tcp_generic</transport_id>
+                </userTransports>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <prefix>63.6c.69.65.6e.74.32.5f.73.31.5f.5f</prefix>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>41812</physical_port>
+                                    <port>41812</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>0</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <participant profile_name="TCP_server_B">
+            <rtps>
+                <userTransports>
+                    <transport_id>tcp_server</transport_id>
+                </userTransports>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <prefix>44.49.53.43.53.45.52.56.45.52.5F.32</prefix>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>SERVER</discoveryProtocol>
+                        <discoveryServersList>
+                            <locator>
+                                <tcpv4>
+                                    <address>127.0.0.1</address>
+                                    <physical_port>41811</physical_port>
+                                    <port>41811</port>
+                                </tcpv4>
+                            </locator>
+                        </discoveryServersList>
+                        <initialAnnouncements>
+                            <count>5</count>
+                        </initialAnnouncements>
+                        <leaseAnnouncement>DURATION_INFINITY</leaseAnnouncement>
+                        <leaseDuration>DURATION_INFINITY</leaseDuration>
+                    </discovery_config>
+                    <metatrafficUnicastLocatorList>
+                        <locator>
+                            <tcpv4>
+                                <address>127.0.0.1</address>
+                                <physical_port>41812</physical_port>
+                                <port>41812</port>
+                            </tcpv4>
+                        </locator>
+                    </metatrafficUnicastLocatorList>
+                </builtin>
+            </rtps>
+        </participant>
+
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+
+     </profiles>
+</DS>

--- a/test/configuration/test_solutions/test_80_auto.snapshot
+++ b/test/configuration/test_solutions/test_80_auto.snapshot
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>test_80_auto_snapshot</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="472">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="118"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="923"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_81_auto_ros_domain_id_env_var.snapshot
+++ b/test/configuration/test_solutions/test_81_auto_ros_domain_id_env_var.snapshot
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>test_81_auto_ros_domain_id_env_var</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client2" discovered_timestamp="472">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="118"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="923"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_82_auto_ros_static_peers_env_var.snapshot
+++ b/test/configuration/test_solutions/test_82_auto_ros_static_peers_env_var.snapshot
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>test_82_auto_ros_static_peers_env_var</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="472">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="118"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="923"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_83_start.snapshot
+++ b/test/configuration/test_solutions/test_83_start.snapshot
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>test_83_start</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="472">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="118"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="923"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_84_add.snapshot
+++ b/test/configuration/test_solutions/test_84_add.snapshot
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>test_84_add</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="472">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="118"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="17">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="923"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_85_set_add_stop.snapshot
+++ b/test/configuration/test_solutions/test_85_set_add_stop.snapshot
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>All_isolated</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S3">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S4">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>S4_isolated</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S3" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S3" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S3">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S4">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>S1_S3_isolated_from_S2_S4</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S3" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S3" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S4" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S3">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S4">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>S1_stopped</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S3" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S3" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S4" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S3">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S1" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S4">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="923"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client1_S2" discovered_timestamp="471">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="17"/>
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.2.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_86_stop_all_servers.snapshot
+++ b/test/configuration/test_solutions/test_86_stop_all_servers.snapshot
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>Servers_up</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S3">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>Servers_down</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client1_S3">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_93_tcp_reconnect_with_clients_A.snapshot
+++ b/test/configuration/test_solutions/test_93_tcp_reconnect_with_clients_A.snapshot
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1632904721368" process_time="2000" last_pdp_callback_time="932" last_edp_callback_time="952" someone="true">
+        <description>Knows server B, client A and client B</description>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="server" discovered_timestamp="14"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="469"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="471">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="927"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="19"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="932">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="952"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+    <DS_Snapshot timestamp="1632904724368" process_time="5000" last_pdp_callback_time="4008" last_edp_callback_time="4006" someone="true">
+        <description>Do not know server B</description>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="469"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="19"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="14"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+    <DS_Snapshot timestamp="1632904727368" process_time="8000" last_pdp_callback_time="6943" last_edp_callback_time="7394" someone="true">
+        <description>Knows server B, client A and client B</description>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="false" alive="true" name="server" discovered_timestamp="6024"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="17">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="469"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="6485">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="6938"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="19"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="14">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="14"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="6943">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="7394"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_93_tcp_reconnect_with_clients_B.snapshot
+++ b/test/configuration/test_solutions/test_93_tcp_reconnect_with_clients_B.snapshot
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1632912492786" process_time="4000" last_pdp_callback_time="922" last_edp_callback_time="936" someone="true">
+        <description>Knows server A, client A and client B</description>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.31" guid_entity="0.0.1.c1" server="false" alive="true" name="server" discovered_timestamp="126"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="466">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="920"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="13">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="465"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="125"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="922">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.31.5f.73.31.5f.5f" guid_entity="0.0.1.3" discovered_timestamp="935"/>
+            </ptdi>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="13">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="13"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+    <DS_Snapshot timestamp="1632912494786" process_time="6000" last_pdp_callback_time="922" last_edp_callback_time="936" someone="true">
+        <description>Do not know server A</description>
+        <ptdb guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="client1" discovered_timestamp="13">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="465"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1">
+            <ptdi guid_prefix="44.49.53.43.53.45.52.56.45.52.5f.32" guid_entity="0.0.1.c1" server="true" alive="true" name="server" discovered_timestamp="125"/>
+            <ptdi guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="13">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="63.6c.69.65.6e.74.32.5f.73.31.5f.5f" guid_entity="0.0.1.4" discovered_timestamp="13"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -3210,6 +3210,88 @@
             }
         },
 
+        "test_93_tcp_reconnect_with_clients":
+        {
+            "description": [
+                "Server B connects with Server A. Server B leaves. Server B turns back with same configuration"
+            ],
+
+            "processes":
+            {
+                "serverA":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_93_tcp_reconnect_with_clients_A.xml",
+                    "validation":
+                    {
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_93_tcp_reconnect_with_clients_A.snapshot"
+                        },
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "generate_validation":
+                        {
+                            "disposals": true,
+                            "server_endpoints": false
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": false,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_93_tcp_reconnect_with_clients_A.snapshot"
+                        }
+                    }
+                },
+
+                "serverB_1":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_93_tcp_reconnect_with_clients_B.xml",
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+
+                "serverB_2":
+                {
+                    "creation_time": 16,
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_93_tcp_reconnect_with_clients_B.xml",
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_93_tcp_reconnect_with_clients_B.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": false,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_93_tcp_reconnect_with_clients_B.snapshot"
+                        }
+                    }
+                }
+            }
+        },
+
         "test_94_tcpv4_custom_guid_transform_locators":
         {
             "description": [

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -2550,7 +2550,7 @@
         "test_80_auto":
         {
             "description": [
-                "Test that two clients with AUTO discovery are able to communicate between themselfs.",
+                "Test that two clients with EASY_MODE discovery are able to communicate between themselfs.",
                 "The server is automatically instantiated using the Fast DDS CLI tool call from Fast DDS."
             ],
 
@@ -2562,8 +2562,8 @@
                     "environment_variables":
                     [
                         {
-                            "name": "ROS_DISCOVERY_SERVER",
-                            "value": "AUTO"
+                            "name": "EASY_MODE",
+                            "value": "127.0.0.1"
                         }
                     ],
                     "validation":
@@ -2593,9 +2593,12 @@
         "test_81_auto_ros_domain_id_env_var":
         {
             "description": [
-                "Test that two clients with AUTO discovery are able to communicate between themselfs.",
+                "Test that two clients with EASY_MODE discovery are able to communicate between themselfs.",
                 "The server is instantiated using the Fast DDS CLI tool with the keyword 'auto'.",
-                "The Domain ID is specified using the ROS_DISCOVERY_SERVER environment variable."
+                "The Domain ID is specified using the ROS_DOMAIN_ID environment variable.",
+                "The EASY_MODE cannot be properly tested in this repo because it is meant for connecting",
+                "different hosts, and the tests are run in the same host. Only its correct parsing and",
+                "server creation is tested here."
             ],
 
             "processes":
@@ -2632,8 +2635,8 @@
                     "environment_variables":
                     [
                         {
-                            "name": "ROS_DISCOVERY_SERVER",
-                            "value": "AUTO"
+                            "name": "EASY_MODE",
+                            "value": "127.0.0.1"
                         }
                     ],
                     "validation":

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -3098,7 +3098,7 @@
         "test_86_stop_all_servers":
         {
             "description": [
-                "This test verifies that 'shutdown' stops all running servers."
+                "This test verifies that 'stop' without '-d' stops all running servers."
             ],
 
             "processes":
@@ -3193,7 +3193,7 @@
                     "kill_time": 8,
                     "tool_config":
                     {
-                        "shutdown" : ""
+                        "stop" : ""
                     },
                     "validation":
                     {

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -2951,7 +2951,7 @@
                 },
                 "cli_auto_d1":
                 {
-                    "kill_time": 20,
+                    "kill_time": 43,
                     "tool_config":
                     {
                         "auto" : "",
@@ -2971,7 +2971,7 @@
                 },
                 "cli_auto_d2":
                 {
-                    "kill_time": 20,
+                    "kill_time": 43,
                     "tool_config":
                     {
                         "auto" : "",
@@ -2991,7 +2991,7 @@
                 },
                 "cli_auto_d3":
                 {
-                    "kill_time": 20,
+                    "kill_time": 43,
                     "tool_config":
                     {
                         "auto" : "",
@@ -3011,7 +3011,7 @@
                 },
                 "cli_auto_d4":
                 {
-                    "kill_time": 20,
+                    "kill_time": 43,
                     "tool_config":
                     {
                         "auto" : "",
@@ -3052,8 +3052,8 @@
                 },
                 "cli_set_d2":
                 {
-                    "creation_time": 10,
-                    "kill_time": 12,
+                    "creation_time": 18,
+                    "kill_time": 20,
                     "tool_config":
                     {
                         "set" : "127.0.0.1:4",
@@ -3073,8 +3073,8 @@
                 },
                 "cli_stop_d1":
                 {
-                    "creation_time": 15,
-                    "kill_time": 17,
+                    "creation_time": 30,
+                    "kill_time": 31,
                     "tool_config":
                     {
                         "stop" : "",

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -3098,7 +3098,7 @@
         "test_86_stop_all_servers":
         {
             "description": [
-                "This test verifies that 'stop all' stops all running servers."
+                "This test verifies that 'shutdown' stops all running servers."
             ],
 
             "processes":
@@ -3193,7 +3193,7 @@
                     "kill_time": 8,
                     "tool_config":
                     {
-                        "stop" : "all"
+                        "shutdown" : ""
                     },
                     "validation":
                     {

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -2547,6 +2547,669 @@
             }
         },
 
+        "test_80_auto":
+        {
+            "description": [
+                "Test that two clients with AUTO discovery are able to communicate between themselfs.",
+                "The server is automatically instantiated using the Fast DDS CLI tool call from Fast DDS."
+            ],
+
+            "processes":
+            {
+                "clients":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_80_auto.xml",
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS_DISCOVERY_SERVER",
+                            "value": "AUTO"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_80_auto.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_80_auto.snapshot"
+                        }
+                    }
+                }
+            }
+        },
+
+        "test_81_auto_ros_domain_id_env_var":
+        {
+            "description": [
+                "Test that two clients with AUTO discovery are able to communicate between themselfs.",
+                "The server is instantiated using the Fast DDS CLI tool with the keyword 'auto'.",
+                "The Domain ID is specified using the ROS_DISCOVERY_SERVER environment variable."
+            ],
+
+            "processes":
+            {
+                "cli_auto":
+                {
+                    "kill_time": 5,
+                    "tool_config":
+                    {
+                        "auto" : ""
+                    },
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS_DOMAIN_ID",
+                            "value": "42"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "clients":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_81_auto_ros_domain_id_env_var.xml",
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS_DISCOVERY_SERVER",
+                            "value": "AUTO"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_81_auto_ros_domain_id_env_var.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_81_auto_ros_domain_id_env_var.snapshot"
+                        }
+                    }
+                }
+            }
+        },
+
+        "test_82_auto_ros_static_peers_env_var":
+        {
+            "description": [
+                "Test that two servers are able to discover each other and exchange data using the 'ROS_STATIC_PEERS'",
+                "environment variable."
+            ],
+
+            "processes":
+            {
+                "clients":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_82_auto_ros_static_peers_env_var.xml",
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_82_auto_ros_static_peers_env_var.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_82_auto_ros_static_peers_env_var.snapshot"
+                        }
+                    }
+                },
+                "cli_auto_d0":
+                {
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "0"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_auto_d3":
+                {
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "3"
+                    },
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS_STATIC_PEERS",
+                            "value": "127.0.0.1:7402"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                }
+            }
+        },
+
+        "test_83_start":
+        {
+            "description": [
+                "Test that two servers are able to discover each other using the 'start' keyword."
+            ],
+
+            "processes":
+            {
+                "clients":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_83_start.xml",
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_83_start.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_83_start.snapshot"
+                        }
+                    }
+                },
+                "cli_auto_d0":
+                {
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "0"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_start_d3":
+                {
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "start" : "127.0.0.1:0",
+                        "domain" : "3"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                }
+            }
+        },
+
+        "test_84_add":
+        {
+            "description": [
+                "Test that two servers are able to discover each other using the 'add' keyword."
+            ],
+
+            "processes":
+            {
+                "main":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_84_add.xml",
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_84_add.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_84_add.snapshot"
+                        }
+                    }
+                },
+                "cli_auto_d0":
+                {
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "0"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_auto_d3":
+                {
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "3"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_add_d3":
+                {
+                    "creation_time": 3,
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "add" : "127.0.0.1:0",
+                        "domain" : "3"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                }
+            }
+        },
+
+        "test_85_set_add_stop":
+        {
+            "description": [
+                "This test verifies:",
+                "1. The 'add' keyword accepts list of locators",
+                "2. The 'set' keyword replaces the list of remote servers (single server)",
+                "3. The 'stop' keyword stops a server and it is undiscovered by the other servers"
+            ],
+
+            "processes":
+            {
+                "main":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_85_set_add_stop.xml",
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_85_set_add_stop.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_85_set_add_stop.snapshot"
+                        }
+                    }
+                },
+                "cli_auto_d1":
+                {
+                    "kill_time": 20,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "1"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_auto_d2":
+                {
+                    "kill_time": 20,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "2"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_auto_d3":
+                {
+                    "kill_time": 20,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "3"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_auto_d4":
+                {
+                    "kill_time": 20,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "4"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_add_d2":
+                {
+                    "creation_time": 4,
+                    "kill_time": 6,
+                    "tool_config":
+                    {
+                        "add" : "127.0.0.1:1;127.0.0.1:3",
+                        "domain" : "2"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_set_d2":
+                {
+                    "creation_time": 10,
+                    "kill_time": 12,
+                    "tool_config":
+                    {
+                        "set" : "127.0.0.1:4",
+                        "domain" : "2"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_stop_d1":
+                {
+                    "creation_time": 15,
+                    "kill_time": 17,
+                    "tool_config":
+                    {
+                        "stop" : "",
+                        "domain" : "1"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                }
+            }
+        },
+
+        "test_86_stop_all_servers":
+        {
+            "description": [
+                "This test verifies that 'stop all' stops all running servers."
+            ],
+
+            "processes":
+            {
+                "main":
+                {
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_86_stop_all_servers.xml",
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_86_stop_all_servers.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_86_stop_all_servers.snapshot"
+                        }
+                    }
+                },
+                "cli_auto_d1":
+                {
+                    "kill_time": 8,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "1"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_auto_d2":
+                {
+                    "kill_time": 8,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "2"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_auto_d3":
+                {
+                    "kill_time": 8,
+                    "tool_config":
+                    {
+                        "auto" : "",
+                        "domain" : "3"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_stop":
+                {
+                    "creation_time": 4,
+                    "kill_time": 8,
+                    "tool_config":
+                    {
+                        "stop" : "all"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                }
+            }
+        },
+
         "test_94_tcpv4_custom_guid_transform_locators":
         {
             "description": [

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -2550,7 +2550,7 @@
         "test_80_auto":
         {
             "description": [
-                "Test that two clients with EASY_MODE discovery are able to communicate between themselfs.",
+                "Test that two clients with ROS2_EASY_MODE discovery are able to communicate between themselfs.",
                 "The server is automatically instantiated using the Fast DDS CLI tool call from Fast DDS."
             ],
 
@@ -2562,7 +2562,7 @@
                     "environment_variables":
                     [
                         {
-                            "name": "EASY_MODE",
+                            "name": "ROS2_EASY_MODE",
                             "value": "127.0.0.1"
                         }
                     ],
@@ -2593,10 +2593,10 @@
         "test_81_auto_ros_domain_id_env_var":
         {
             "description": [
-                "Test that two clients with EASY_MODE discovery are able to communicate between themselfs.",
+                "Test that two clients with ROS2_EASY_MODE discovery are able to communicate between themselfs.",
                 "The server is instantiated using the Fast DDS CLI tool with the keyword 'auto'.",
                 "The Domain ID is specified using the ROS_DOMAIN_ID environment variable.",
-                "The EASY_MODE cannot be properly tested in this repo because it is meant for connecting",
+                "The ROS2_EASY_MODE cannot be properly tested in this repo because it is meant for connecting",
                 "different hosts, and the tests are run in the same host. Only its correct parsing and",
                 "server creation is tested here."
             ],
@@ -2635,7 +2635,7 @@
                     "environment_variables":
                     [
                         {
-                            "name": "EASY_MODE",
+                            "name": "ROS2_EASY_MODE",
                             "value": "127.0.0.1"
                         }
                     ],

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -238,7 +238,7 @@ async def run_command(process_args, environment, timeout):
     # There are three kinds of processes:
     # a) Standard processes which consist of a domain participant with a XML configuration file. These
     #    processes are stopped by sending a SIGINT signal to the process. They do not have childs.
-    # b) Fast DDS CLI commands in AUTO mode (with daemon). Theses processes do not require to manually
+    # b) Fast DDS CLI commands in EASY_MODE (with daemon). Theses processes do not require to manually
     #    stop them, as the daemon will stop them automatically after calling it (fastdds discovery stop).
     #    Hence, the executed process (python parser) will end and we will fail to the the parent process,
     #    raising the exception.
@@ -259,7 +259,7 @@ async def run_command(process_args, environment, timeout):
             proc.send_signal(signal.SIGINT)
         time.sleep(1)
     except Exception:
-        # b) Fast DDS CLI in AUTO mode
+        # b) Fast DDS CLI in EASY_MODE
         pass
 
     try:
@@ -277,7 +277,7 @@ async def run_command(process_args, environment, timeout):
             proc.kill()
 
     except Exception:
-        # b) Fast DDS CLI in AUTO mode
+        # b) Fast DDS CLI in EASY_MODE
         pass
 
     return (await proc.wait(), num_lines[1])
@@ -368,7 +368,7 @@ def execute_validate_thread_test(
         server_udp_port = None
         server_tcp_address = None
         server_tcp_port = None
-        # Discovery Server Auto mode
+        # Discovery Server EASY_MODE
         auto_keyword = None
         start_keyword = None
         stop_keyword = None
@@ -415,7 +415,7 @@ def execute_validate_thread_test(
     # Wait for initial time
     time.sleep(creation_time)
 
-    # Save domain used with AUTO mode
+    # Save domain used with EASY_MODE
     ros_domain_id_value = None
     # Set env var
     my_env = os.environ.copy()
@@ -521,7 +521,7 @@ def execute_validate_thread_test(
 
     #######
     # CLEAN
-    # Stop fastdds DS started with the tool (only if run with AUTO mode)
+    # Stop fastdds DS started with the tool (only if run with EASY_MODE)
     if stop_domain is not None:
         # Wait for kill time
         logger.debug(f'Waiting for {kill_time - creation_time} seconds to kill server in domain [{stop_domain}]')
@@ -967,7 +967,7 @@ if __name__ == '__main__':
     )
 
     # Stop all fastdds tool processes and the daemon. It is needed for servers
-    # started with the ROS_DISCOVERY_SERVER=AUTO environment variable
+    # started with the EASY_MODE environment variable
     if args.fds is not None:
         stop_args = [args.fds]
         stop_args.extend(['discovery', 'stop'])

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -238,7 +238,7 @@ async def run_command(process_args, environment, timeout):
     # There are three kinds of processes:
     # a) Standard processes which consist of a domain participant with a XML configuration file. These
     #    processes are stopped by sending a SIGINT signal to the process. They do not have childs.
-    # b) Fast DDS CLI commands in EASY_MODE (with daemon). Theses processes do not require to manually
+    # b) Fast DDS CLI commands in ROS2_EASY_MODE (with daemon). Theses processes do not require to manually
     #    stop them, as the daemon will stop them automatically after calling it (fastdds discovery stop).
     #    Hence, the executed process (python parser) will end and we will fail to the the parent process,
     #    raising the exception.
@@ -259,7 +259,7 @@ async def run_command(process_args, environment, timeout):
             proc.send_signal(signal.SIGINT)
         time.sleep(1)
     except Exception:
-        # b) Fast DDS CLI in EASY_MODE
+        # b) Fast DDS CLI in ROS2_EASY_MODE
         pass
 
     try:
@@ -277,7 +277,7 @@ async def run_command(process_args, environment, timeout):
             proc.kill()
 
     except Exception:
-        # b) Fast DDS CLI in EASY_MODE
+        # b) Fast DDS CLI in ROS2_EASY_MODE
         pass
 
     return (await proc.wait(), num_lines[1])
@@ -368,7 +368,7 @@ def execute_validate_thread_test(
         server_udp_port = None
         server_tcp_address = None
         server_tcp_port = None
-        # Discovery Server EASY_MODE
+        # Discovery Server ROS2_EASY_MODE
         auto_keyword = None
         start_keyword = None
         stop_keyword = None
@@ -415,7 +415,7 @@ def execute_validate_thread_test(
     # Wait for initial time
     time.sleep(creation_time)
 
-    # Save domain used with EASY_MODE
+    # Save domain used with ROS2_EASY_MODE
     ros_domain_id_value = None
     # Set env var
     my_env = os.environ.copy()
@@ -521,7 +521,7 @@ def execute_validate_thread_test(
 
     #######
     # CLEAN
-    # Stop fastdds DS started with the tool (only if run with EASY_MODE)
+    # Stop fastdds DS started with the tool (only if run with ROS2_EASY_MODE)
     if stop_domain is not None:
         # Wait for kill time
         logger.debug(f'Waiting for {kill_time - creation_time} seconds to kill server in domain [{stop_domain}]')
@@ -967,7 +967,7 @@ if __name__ == '__main__':
     )
 
     # Stop all fastdds tool processes and the daemon. It is needed for servers
-    # started with the EASY_MODE environment variable
+    # started with the ROS2_EASY_MODE environment variable
     if args.fds is not None:
         stop_args = [args.fds]
         stop_args.extend(['discovery', 'stop'])


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds new tests for the new feature of `Easy Mode`. Tests encompasses both the new environment variable `EASY_MODE` and all the possible commands available in the Fast DDS CLI.
It also adds a new regression test for TCP servers re-connection (`test_93`).

Merge after:

- https://github.com/eProsima/Fast-DDS/pull/5548

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- _N/A_ Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] New feature has been documented/Current behavior is correctly described in the documentation.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
