### PR TITLE
[23008] Update CLI commands for Easy Mode

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,7 @@ list(APPEND TEST_LIST
         test_84_add
         test_85_set_add_stop
         test_86_stop_all_servers
+        test_87_set_modifies_env_var
 
         test_93_tcp_reconnect_with_clients
         test_94_tcpv4_custom_guid_transform_locators

--- a/test/configuration/test_cases/test_87_set_modifies_env_var_A.xml
+++ b/test/configuration/test_cases/test_87_set_modifies_env_var_A.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- Servers are created with Fast DDS CLI tool in ROS2_EASY_MODE.
+         Clients must be able to connect to the server after 'set' is used:
+         Snapshot 1 (Server knows no-one):
+         - Fast DDS CLI tool is called with the 'set' keyword argument.
+         Snapshot 2 (Servers knows the client):
+    -->
+
+    <simples>
+        <simple name="client_fail_1">
+            <publisher topic="topic1"/>
+        </simple>
+        <simple name="client_fail_2">
+            <subscriber topic="topic1"/>
+        </simple>
+    </simples>
+
+    <snapshots file="./test_87_set_modifies_env_var_A.snapshot~">
+        <snapshot time="4">Incorrect_value</snapshot>
+    </snapshots>
+
+    <profiles>
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+     </profiles>
+</DS>

--- a/test/configuration/test_cases/test_87_set_modifies_env_var_B.xml
+++ b/test/configuration/test_cases/test_87_set_modifies_env_var_B.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+
+    <!-- Servers are created with Fast DDS CLI tool in ROS2_EASY_MODE.
+         Clients must be able to connect to the server after 'set' is used:
+         Snapshot 1 (Server knows no-one):
+         - Fast DDS CLI tool is called with the 'set' keyword argument.
+         Snapshot 2 (Servers knows the client):
+    -->
+
+    <simples>
+        <simple name="client_ok_1">
+            <publisher topic="topic1"/>
+        </simple>
+        <simple name="client_ok_2">
+            <subscriber topic="topic1"/>
+        </simple>
+    </simples>
+
+    <snapshots file="./test_87_set_modifies_env_var_B.snapshot~">
+        <snapshot time="3">Correct_value</snapshot>
+    </snapshots>
+
+    <profiles>
+        <topic profile_name="topic1">
+            <name>topic_1</name>
+            <dataType>HelloWorld</dataType>
+        </topic>
+     </profiles>
+</DS>

--- a/test/configuration/test_solutions/test_87_set_modifies_env_var_A.snapshot
+++ b/test/configuration/test_solutions/test_87_set_modifies_env_var_A.snapshot
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>Incorrect_value</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client_fail_1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="77">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="77"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client_fail_2" discovered_timestamp="149">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="261"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client_fail_2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client_fail_1" discovered_timestamp="150">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="261"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="149">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="149"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/test_solutions/test_87_set_modifies_env_var_B.snapshot
+++ b/test/configuration/test_solutions/test_87_set_modifies_env_var_B.snapshot
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DS_Snapshots xmlns="http://www.eprosima.com/XMLSchemas/ds-snapshot">
+    <DS_Snapshot timestamp="1713777801549" process_time="6001" last_pdp_callback_time="472" last_edp_callback_time="923" someone="true">
+        <description>Correct_value</description>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client_ok_1">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="75">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="75"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client_ok_2" discovered_timestamp="644">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="1094"/>
+            </ptdi>
+        </ptdb>
+        <ptdb guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" name="client_ok_2">
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="true" alive="true" name="DiscoveryServerAuto" discovered_timestamp="113"/>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="client_ok_1" discovered_timestamp="578">
+                <publisher type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.3" discovered_timestamp="644"/>
+            </ptdi>
+            <ptdi guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.c1" server="false" alive="true" name="" discovered_timestamp="137">
+                <subscriber type="HelloWorld" topic="topic_1" guid_prefix="XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX.XX" guid_entity="0.0.1.4" discovered_timestamp="137"/>
+            </ptdi>
+        </ptdb>
+    </DS_Snapshot>
+</DS_Snapshots>

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -2595,7 +2595,7 @@
             "description": [
                 "Test that two clients with ROS2_EASY_MODE discovery are able to communicate between themselfs.",
                 "The server is instantiated using the Fast DDS CLI tool with the keyword 'auto'.",
-                "The Domain ID is specified using the ROS_DOMAIN_ID environment variable.",
+                "The Domain ID is specified trhough the CLI and the ROS_DOMAIN_ID variable is ignored.",
                 "The ROS2_EASY_MODE cannot be properly tested in this repo because it is meant for connecting",
                 "different hosts, and the tests are run in the same host. Only its correct parsing and",
                 "server creation is tested here."
@@ -2608,13 +2608,14 @@
                     "kill_time": 5,
                     "tool_config":
                     {
-                        "auto" : ""
+                        "auto" : "127.0.0.1:0",
+                        "domain" : "42"
                     },
                     "environment_variables":
                     [
                         {
                             "name": "ROS_DOMAIN_ID",
-                            "value": "42"
+                            "value": "7"
                         }
                     ],
                     "validation":
@@ -2666,8 +2667,8 @@
         "test_82_auto_ros_static_peers_env_var":
         {
             "description": [
-                "Test that two servers are able to discover each other and exchange data using the 'ROS_STATIC_PEERS'",
-                "environment variable."
+                "Test that two servers are able to discover each other and exchange data using the connection",
+                "passed through the CLI."
             ],
 
             "processes":
@@ -2701,7 +2702,7 @@
                     "kill_time": 6,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:0",
                         "domain" : "0"
                     },
                     "validation":
@@ -2721,16 +2722,9 @@
                     "kill_time": 6,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:0",
                         "domain" : "3"
                     },
-                    "environment_variables":
-                    [
-                        {
-                            "name": "ROS_STATIC_PEERS",
-                            "value": "127.0.0.1:7402"
-                        }
-                    ],
                     "validation":
                     {
                         "exit_code_validation":
@@ -2783,7 +2777,7 @@
                     "kill_time": 6,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:0",
                         "domain" : "0"
                     },
                     "validation":
@@ -2858,7 +2852,7 @@
                     "kill_time": 6,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:0",
                         "domain" : "0"
                     },
                     "validation":
@@ -2878,7 +2872,7 @@
                     "kill_time": 6,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:3",
                         "domain" : "3"
                     },
                     "validation":
@@ -2957,7 +2951,7 @@
                     "kill_time": 43,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:1",
                         "domain" : "1"
                     },
                     "validation":
@@ -2977,7 +2971,7 @@
                     "kill_time": 43,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:2",
                         "domain" : "2"
                     },
                     "validation":
@@ -2997,7 +2991,7 @@
                     "kill_time": 43,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:3",
                         "domain" : "3"
                     },
                     "validation":
@@ -3017,7 +3011,7 @@
                     "kill_time": 43,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:4",
                         "domain" : "4"
                     },
                     "validation":
@@ -3135,7 +3129,7 @@
                     "kill_time": 8,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:1",
                         "domain" : "1"
                     },
                     "validation":
@@ -3155,7 +3149,7 @@
                     "kill_time": 8,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:2",
                         "domain" : "2"
                     },
                     "validation":
@@ -3175,7 +3169,7 @@
                     "kill_time": 8,
                     "tool_config":
                     {
-                        "auto" : "",
+                        "auto" : "127.0.0.1:3",
                         "domain" : "3"
                     },
                     "validation":

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -2595,7 +2595,7 @@
             "description": [
                 "Test that two clients with ROS2_EASY_MODE discovery are able to communicate between themselfs.",
                 "The server is instantiated using the Fast DDS CLI tool with the keyword 'auto'.",
-                "The Domain ID is specified trhough the CLI and the ROS_DOMAIN_ID variable is ignored.",
+                "The Domain ID is specified through the CLI and the ROS_DOMAIN_ID variable is ignored.",
                 "The ROS2_EASY_MODE cannot be properly tested in this repo because it is meant for connecting",
                 "different hosts, and the tests are run in the same host. Only its correct parsing and",
                 "server creation is tested here."

--- a/test/configuration/tests_params.json
+++ b/test/configuration/tests_params.json
@@ -3207,6 +3207,122 @@
             }
         },
 
+        "test_87_set_modifies_env_var":
+        {
+            "description": [
+                "This test verifies that 'set' modifies the remote connection of a server."
+            ],
+
+            "processes":
+            {
+                "client_incorrect":
+                {
+                    "creation_time": 1,
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_87_set_modifies_env_var_A.xml",
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS2_EASY_MODE",
+                            "value": "127.0.0.1"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 4
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_87_set_modifies_env_var_A.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_87_set_modifies_env_var_A.snapshot"
+                        }
+                    }
+                },
+                "cli_auto":
+                {
+                    "kill_time": 11,
+                    "tool_config":
+                    {
+                        "auto" : "127.1.1.1:42",
+                        "domain" : "42"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "cli_set":
+                {
+                    "creation_time": 5,
+                    "kill_time": 7,
+                    "tool_config":
+                    {
+                        "set" : "127.0.0.1:42",
+                        "domain" : "42"
+                    },
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        }
+                    }
+                },
+                "client_ok":
+                {
+                    "creation_time": 6,
+                    "xml_config_file": "<CONFIG_RELATIVE_PATH>/test_cases/test_87_set_modifies_env_var_B.xml",
+                    "environment_variables":
+                    [
+                        {
+                            "name": "ROS2_EASY_MODE",
+                            "value": "127.0.0.1"
+                        }
+                    ],
+                    "validation":
+                    {
+                        "exit_code_validation":
+                        {
+                            "expected_exit_code": 0
+                        },
+                        "stderr_validation":
+                        {
+                            "err_expected_lines": 0
+                        },
+                        "count_lines_validation":
+                        {
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_87_set_modifies_env_var_B.snapshot"
+                        },
+                        "ground_truth_validation":
+                        {
+                            "guidless": true,
+                            "file_path": "<CONFIG_RELATIVE_PATH>/test_solutions/test_87_set_modifies_env_var_B.snapshot"
+                        }
+                    }
+                }
+            }
+        },
+
         "test_93_tcp_reconnect_with_clients":
         {
             "description": [

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -442,6 +442,7 @@ def execute_validate_thread_test(
         if auto_keyword is not None:
             stop_domain = 0 if ros_domain_id_value is None else ros_domain_id_value
             process_args.append(Command.AUTO.value)
+            process_args.append(str(auto_keyword))
         elif start_keyword is not None:
             stop_domain = 0 if ros_domain_id_value is None else ros_domain_id_value
             process_args.append(Command.START.value)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR updated the CLI API calls according to: 

- https://github.com/eProsima/Fast-DDS/pull/5749

It also adds a new test to verify the modification of the remote connection stored by the daemon after a `set` command.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.0.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- _N/A_ Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] New feature has been documented/Current behavior is correctly described in the documentation.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
