### PR TITLE
[23100] Preserve Workspace permissions across shared artifacts in CI

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -141,11 +141,14 @@ jobs:
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
 
+      - name: 'Tar workspace'
+        run: tar -cvf github_ws.tar ${{ github.workspace }}
+
       - name: Upload build artifacts
         uses: eProsima/eProsima-CI/external/upload-artifact@v0
         with:
           name: discovery_server_build_${{ inputs.label }}
-          path: ${{ github.workspace }}
+          path: github_ws.tar
 
   discovery_server_tests:
     needs: discovery_server_build
@@ -160,7 +163,9 @@ jobs:
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
           name: discovery_server_build_${{ inputs.label }}
-          path: ${{ github.workspace }}
+
+      - name: 'Restore workspace'
+        run: tar -xvf github_ws.tar -C ${{ github.workspace }} --strip-components=5
 
       - name: Install Fix Python version
         uses: eProsima/eProsima-CI/external/setup-python@v0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

The `upload-artifacts` github action do not preserve executable permissions. `fastddds-discovery-server` symlink permissions are also packed with read-only. `chmod`cannot change a symlink permissions.

This PR `tars` and decompresses the github workspace in order to preserve executable permissions accros build and test.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.0.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The added tests pass locally.
- **N/A** Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
