### PR TITLE
Fix test 13

### DIFF
--- a/test/configuration/test_cases/test_13_disposals_single_server.xml
+++ b/test/configuration/test_cases/test_13_disposals_single_server.xml
@@ -129,7 +129,7 @@
         <snapshot time="20">test_13_disposals_single_server_8.[P1,P2]_-_9.[S1,S2]</snapshot>
         <snapshot time="23">test_13_disposals_single_server_8.P2_-_9.S2</snapshot>
 
-        <snapshot time="26">test_13_disposals_single_server_a.P1_-_b.S1</snapshot>
+        <snapshot time="27">test_13_disposals_single_server_a.P1_-_b.S1</snapshot>
         <snapshot time="30">test_13_disposals_single_server_a_-_b</snapshot>
 
         <snapshot time="34">test_13_disposals_single_server_c.S1_-_d.P1</snapshot>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR fixes test 13 of discovery server by correctly setting the timestamp of snapshot `test_13_disposals_single_server_a.P1_-_b.S1`. For some reason, this snapshot was not reflecting the test chronology described at the beginning of the test case. This was corrected during the [Discovery Server refactor](https://github.com/eProsima/Discovery-Server/pull/76) in master, but it was never backported. The test started failing after https://github.com/eProsima/Fast-DDS/pull/5556.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.0.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- _N/A_ Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
