### PR TITLE
Adding new log macros to 1.2.x

### DIFF
--- a/src/DSLog.h.in
+++ b/src/DSLog.h.in
@@ -33,9 +33,18 @@
 
 #include <fastrtps/log/Log.h>
 
-#define LOG(x) logInfo(DISCOVERY_SERVER,x)
-#define LOG_INFO(x) logInfo(DISCOVERY_SERVER,x)
-#define LOG_WARN(x) logWarning(DISCOVERY_SERVER,x)
-#define LOG_ERROR(x) logError(DISCOVERY_SERVER,x)
+#if ENABLE_OLD_LOG_MACROS_
+    // Old log macros are kept for compatibility.
+    #define LOG(x) logInfo(DISCOVERY_SERVER,x)
+    #define LOG_INFO(x) logInfo(DISCOVERY_SERVER,x)
+    #define LOG_WARN(x) logWarning(DISCOVERY_SERVER,x)
+    #define LOG_ERROR(x) logError(DISCOVERY_SERVER,x)
+#else
+    // New log macros
+    #define LOG(x) EPROSIMA_LOG_INFO(DISCOVERY_SERVER,x)
+    #define LOG_INFO(x) EPROSIMA_LOG_INFO(DISCOVERY_SERVER,x)
+    #define LOG_WARN(x) EPROSIMA_LOG_WARNING(DISCOVERY_SERVER,x)
+    #define LOG_ERROR(x) EPROSIMA_LOG_ERROR(DISCOVERY_SERVER,x)
+#endif // ENABLE_OLD_LOG_MACROS_
 
 #endif // _EPROSIMA_IS_LOG_H_


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Updating the log macros in fastrtps 2.14 forces us to also update the macros in discovery server.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.1.x 2.0.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- [x] Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] New feature has been documented/Current behavior is correctly described in the documentation.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
