### PR TITLE
[24122] Fix warning on ubuntu noble

### DIFF
--- a/src/DiscoveryServerManager.cpp
+++ b/src/DiscoveryServerManager.cpp
@@ -113,8 +113,7 @@ DiscoveryServerManager::DiscoveryServerManager(
                 tinyxml2::XMLPrinter printer;
                 profiles->Accept(&printer);
                 std::string xmlString = R"(")" + std::string(printer.CStr()) + R"(")";
-                if (RETCODE_OK ==
-                        DomainParticipantFactory::get_instance()->load_XML_profiles_string(xmlString.c_str(),
+                if (RETCODE_OK == DomainParticipantFactory::get_instance()->load_XML_profiles_string(xmlString.c_str(),
                         std::string(printer.CStr()).length()))
                 {
                     LOG_INFO("Profiles parsed successfully.");
@@ -134,7 +133,7 @@ DiscoveryServerManager::DiscoveryServerManager(
                         auto topic_desc_it = topic_description_profiles_map.find(topic_profile_name);
                         if (topic_desc_it == topic_description_profiles_map.end())
                         {
-                            auto &topic_desc = topic_description_profiles_map[topic_profile_name];
+                            auto& topic_desc = topic_description_profiles_map[topic_profile_name];
                             if (!fill_topic_description_profile(topic_profile, topic_desc))
                             {
                                 LOG_ERROR("Error parsing topic profiles");
@@ -704,8 +703,8 @@ Topic* DiscoveryServerManager::getParticipantTopicByName(
 }
 
 bool DiscoveryServerManager::fill_topic_description_profile(
-    tinyxml2::XMLElement* elem,
-    TopicDescriptionItem& topic_description)
+        tinyxml2::XMLElement* elem,
+        TopicDescriptionItem& topic_description)
 {
     /*
         <xs:complexType name="topicDescriptionType">
@@ -714,50 +713,50 @@ bool DiscoveryServerManager::fill_topic_description_profile(
                 <xs:element name="dataType" type="stringType" minOccurs="0"/>
         </xs:all>
         </xs:complexType>
-    */
+     */
 
     bool ret = true;
     tinyxml2::XMLElement* p_aux0 = elem->FirstChildElement();
     const char* name = nullptr;
     for (; p_aux0 != NULL; p_aux0 = p_aux0->NextSiblingElement())
     {
-            name = p_aux0->Name();
+        name = p_aux0->Name();
 
-            if (strcmp(name, DSxmlparser::NAME) == 0)
+        if (strcmp(name, DSxmlparser::NAME) == 0)
+        {
+            // name - stringType
+            const char* text = p_aux0->GetText();
+            if (nullptr != text)
             {
-                // name - stringType
-                const char* text = p_aux0->GetText();
-                if (nullptr != text)
-                {
-                    topic_description.name = text;
-                }
-                else
-                {
-                    LOG_ERROR("<" << p_aux0->Value() << "> GetText XML_ERROR");
-                    ret = false;
-                    break;
-                }
-            }
-            else if (strcmp(name, DSxmlparser::DATA_TYPE) == 0)
-            {
-                // dataType - stringType
-                const char* text = p_aux0->GetText();
-                if (nullptr != text)
-                {
-                    topic_description.type_name = text;
-                }
-                else
-                {
-                    LOG_ERROR("<" << p_aux0->Value() << "> GetText XML_ERROR");
-                    ret = false;
-                    break;
-                }
+                topic_description.name = text;
             }
             else
             {
-                LOG_ERROR("Invalid element found into 'topicDescriptionType'. Name: " << name);
+                LOG_ERROR("<" << p_aux0->Value() << "> GetText XML_ERROR");
                 ret = false;
+                break;
             }
+        }
+        else if (strcmp(name, DSxmlparser::DATA_TYPE) == 0)
+        {
+            // dataType - stringType
+            const char* text = p_aux0->GetText();
+            if (nullptr != text)
+            {
+                topic_description.type_name = text;
+            }
+            else
+            {
+                LOG_ERROR("<" << p_aux0->Value() << "> GetText XML_ERROR");
+                ret = false;
+                break;
+            }
+        }
+        else
+        {
+            LOG_ERROR("Invalid element found into 'topicDescriptionType'. Name: " << name);
+            ret = false;
+        }
     }
 
     return ret;
@@ -925,9 +924,7 @@ void DiscoveryServerManager::loadServer(
     GuidPrefix_t& prefix = dpQOS.wire_protocol().prefix;
     const char* cprefix = server->Attribute(DSxmlparser::PREFIX);
 
-    if (cprefix != nullptr &&
-            !(std::istringstream(cprefix) >> prefix) &&
-            (prefix == c_GuidPrefix_Unknown))
+    if (cprefix != nullptr && !(std::istringstream(cprefix) >> prefix) && (prefix == c_GuidPrefix_Unknown))
     {
         LOG_ERROR("Servers cannot have a framework provided prefix"); // at least for now
         return;
@@ -936,8 +933,7 @@ void DiscoveryServerManager::loadServer(
     GUID_t guid(prefix, c_EntityId_RTPSParticipant);
 
     // Check if the guidPrefix is already in use (there is a mistake on config file)
-    if (enable_prefix_validation &&
-            servers.find(guid) != servers.end())
+    if (enable_prefix_validation && servers.find(guid) != servers.end())
     {
         LOG_ERROR("DiscoveryServerManager detected two servers sharing the same prefix " << prefix);
         return;
@@ -946,8 +942,7 @@ void DiscoveryServerManager::loadServer(
     // replace the DomainParticipantQOS builtin lists with the ones from server_locators (if present)
     // note that a previous call to DiscoveryServerManager::MapServerInfo
     serverLocator_map::mapped_type& lists = server_locators[guid];
-    if (!lists.first.empty() ||
-            !lists.second.empty())
+    if (!lists.first.empty() || !lists.second.empty())
     {
         // server elements take precedence over profile ones
         // I copy them because other servers may need this values
@@ -967,7 +962,8 @@ void DiscoveryServerManager::loadServer(
     // We define the PDP as external (when moved to fast library it would be SERVER)
     DiscoverySettings& b = dpQOS.wire_protocol().builtin.discovery_config;
     (void)b;
-    assert(b.discoveryProtocol == eprosima::fastdds::rtps::DiscoveryProtocol::SERVER || b.discoveryProtocol == eprosima::fastdds::rtps::DiscoveryProtocol::BACKUP);
+    assert(b.discoveryProtocol == eprosima::fastdds::rtps::DiscoveryProtocol::SERVER ||
+            b.discoveryProtocol == eprosima::fastdds::rtps::DiscoveryProtocol::BACKUP);
 
     // Create the participant or the associated events
     DelayedParticipantCreation event(creation_time, std::move(dpQOS), &DiscoveryServerManager::addServer);
@@ -1053,8 +1049,7 @@ void DiscoveryServerManager::loadClient(
     if (dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::CLIENT &&
             dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SUPER_CLIENT)
     {
-        LOG_ERROR(
-            "DiscoveryServerManager::loadClient try to create a client with an incompatible profile: " <<
+        LOG_ERROR("DiscoveryServerManager::loadClient try to create a client with an incompatible profile: " <<
                 profile_name);
         return;
     }
@@ -1103,7 +1098,7 @@ void DiscoveryServerManager::loadClient(
                 if (!p4)
                 {
                     // try to find a descriptor matching the listener port setup
-                    if (p4 = std::dynamic_pointer_cast<TCPv4TransportDescriptor>(sp))
+                    if ((p4 = std::dynamic_pointer_cast<TCPv4TransportDescriptor>(sp)))
                     {
                         continue;
                     }
@@ -1267,8 +1262,8 @@ void DiscoveryServerManager::loadSimple(
         if (dpQOS.wire_protocol().builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SIMPLE)
         {
             LOG_ERROR(
-                "DiscoveryServerManager::loadSimple try to create a simple participant with an incompatible profile: " <<
-                    profile_name);
+                "DiscoveryServerManager::loadSimple try to create a simple participant with an incompatible profile: "
+                    << profile_name);
             return;
         }
 
@@ -1419,9 +1414,8 @@ void DiscoveryServerManager::loadSubscriber(
         endpoint_profile = std::string(profile_name);
     }
 
-    DelayedEndpointCreation<DataReader> event(creation_time, topic_description.name,
-            topic_description.type_name, topic_name, endpoint_profile, part_guid, pDE,
-            participant_creation_event);
+    DelayedEndpointCreation<DataReader> event(creation_time, topic_description.name, topic_description.type_name,
+            topic_name, endpoint_profile, part_guid, pDE, participant_creation_event);
 
     if (creation_time == getTime())
     {
@@ -1525,9 +1519,8 @@ void DiscoveryServerManager::loadPublisher(
         endpoint_profile = std::string(profile_name);
     }
 
-    DelayedEndpointCreation<DataWriter> event(creation_time, topic_description.name,
-            topic_description.type_name, topic_name, endpoint_profile, part_guid, pDE,
-            participant_creation_event);
+    DelayedEndpointCreation<DataWriter> event(creation_time, topic_description.name, topic_description.type_name,
+            topic_name, endpoint_profile, part_guid, pDE, participant_creation_event);
 
     if (creation_time == getTime())
     {
@@ -1637,8 +1630,7 @@ void DiscoveryServerManager::MapServerInfo(
     // I must load the prefix from the profile
     // retrieve profile QOS
     pqos = std::make_shared<DomainParticipantQos>();
-    if (RETCODE_OK !=
-            DomainParticipantFactory::get_instance()->get_participant_qos_from_profile(profile_name, *pqos))
+    if (RETCODE_OK != DomainParticipantFactory::get_instance()->get_participant_qos_from_profile(profile_name, *pqos))
     {
         LOG_ERROR("DiscoveryServerManager::loadServer couldn't load profile " << profile_name);
         return;
@@ -1690,8 +1682,8 @@ void DiscoveryServerManager::on_participant_discovery(
         return;
     }
 
-    LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a participant "
-                            << info.participant_name << " is " << status << ". Prefix " << partid);
+    LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a participant " <<
+            info.participant_name << " is " << status << ". Prefix " << partid);
 
     std::chrono::steady_clock::time_point callback_time = std::chrono::steady_clock::now();
     {
@@ -1714,8 +1706,7 @@ void DiscoveryServerManager::on_participant_discovery(
     {
         case ParticipantDiscoveryStatus::DISCOVERED_PARTICIPANT:
         {
-            state.AddParticipant(srcGuid, srcName, partid, info.participant_name.to_string(), callback_time,
-                    server);
+            state.AddParticipant(srcGuid, srcName, partid, info.participant_name.to_string(), callback_time, server);
             break;
         }
         case ParticipantDiscoveryStatus::REMOVED_PARTICIPANT:
@@ -1765,8 +1756,7 @@ void DiscoveryServerManager::on_data_reader_discovery(
         if (!no_callbacks)
         {
             // is one of ours?
-            if ((it = servers.find(partid)) != servers.end() ||
-                    (it = clients.find(partid)) != clients.end() ||
+            if ((it = servers.find(partid)) != servers.end() || (it = clients.find(partid)) != clients.end() ||
                     (it = simples.find(partid)) != simples.end())
             {
                 part_name = it->second->get_qos().name().to_string();
@@ -1806,9 +1796,9 @@ void DiscoveryServerManager::on_data_reader_discovery(
             break;
     }
 
-    LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a subscriber of participant "
-                            << part_name << " is " << reason << " with typename: " << info.type_name
-                            << " topic: " << info.topic_name << " GUID: " << subsid);
+    LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a subscriber of participant " <<
+            part_name << " is " << reason << " with typename: " << info.type_name << " topic: " << info.topic_name <<
+            " GUID: " << subsid);
 }
 
 void DiscoveryServerManager::on_data_writer_discovery(
@@ -1847,8 +1837,7 @@ void DiscoveryServerManager::on_data_writer_discovery(
             // is one of ours?
             participant_map::iterator it;
 
-            if ((it = servers.find(partid)) != servers.end() ||
-                    (it = clients.find(partid)) != clients.end() ||
+            if ((it = servers.find(partid)) != servers.end() || (it = clients.find(partid)) != clients.end() ||
                     (it = simples.find(partid)) != simples.end())
             {
                 part_name = it->second->get_qos().name().to_string();
@@ -1879,13 +1868,8 @@ void DiscoveryServerManager::on_data_writer_discovery(
     {
         case DS::DISCOVERED_WRITER:
 
-            state.AddDataWriter(srcGuid,
-                    srcName,
-                    partid,
-                    pubsid,
-                    info.type_name.to_string(),
-                    info.topic_name.to_string(),
-                    callback_time);
+            state.AddDataWriter(srcGuid, srcName, partid, pubsid, info.type_name.to_string(),
+                    info.topic_name.to_string(), callback_time);
             break;
         case DS::REMOVED_WRITER:
 
@@ -1895,9 +1879,9 @@ void DiscoveryServerManager::on_data_writer_discovery(
             break;
     }
 
-    LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a publisher of participant "
-                            << part_name << " is " << reason << " with typename: " << info.type_name
-                            << " topic: " << info.topic_name << " GUID: " << pubsid);
+    LOG_INFO("Participant " << participant->get_qos().name().to_string() << " reports a publisher of participant " <<
+            part_name << " is " << reason << " with typename: " << info.type_name << " topic: " << info.topic_name <<
+            " GUID: " << pubsid);
 }
 
 void DiscoveryServerManager::on_liveliness_changed(
@@ -2002,15 +1986,15 @@ Snapshot& DiscoveryServerManager::takeSnapshot(
     temp.insert(clients.begin(), clients.end());
     temp.insert(simples.begin(), simples.end());
 
-    std::function<bool(const participant_map::value_type&, const Snapshot::value_type&)> pred(
-        [](const participant_map::value_type& p1, const Snapshot::value_type& p2)
-        {
-            return p1.first == p2.endpoint_guid;
-        }
-        );
+    std::function<bool(const participant_map::value_type&,
+            const Snapshot::value_type&)> pred([](const participant_map::value_type& p1, const Snapshot::value_type& p2)
+            {
+                return p1.first == p2.endpoint_guid;
+            }
+            );
 
-    std::pair<participant_map::const_iterator, Snapshot::const_iterator> res =
-            std::mismatch(temp.cbegin(), temp.cend(), shot.cbegin(), shot.cend(), pred);
+    std::pair<participant_map::const_iterator, Snapshot::const_iterator> res = std::mismatch(temp.cbegin(), temp.cend(),
+                    shot.cbegin(), shot.cend(), pred);
 
     while (res.first != temp.end())
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR fixes:

```
../../eprosima/discovery-server/src/DiscoveryServerManager.cpp: In member function ‘void eprosima::discovery_server::DiscoveryServerManager::loadClient(tinyxml2::XMLElement*)’:
../../eprosima/discovery-server/src/DiscoveryServerManager.cpp:1106:28: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
 1106 |                     if (p4 = std::dynamic_pointer_cast<TCPv4TransportDescriptor>(sp))
      |                         ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.1.x 2.0.x 1.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- [x] Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] New feature has been documented/Current behavior is correctly described in the documentation.
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
