### PR TITLE
Fix 'exitcode' failures due to Ubuntu Noble Upgrade

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -210,10 +210,15 @@ async def read_outputs(proc, num_lines):
     """
     await asyncio.gather(read_output(proc.stdout, num_lines, 0), read_output(proc.stderr, num_lines, 1))
 
-
-async def run_command(process_args, environment, timeout):
+def run_command_sync(process_args, environment, timeout):
     """
-    Execute a process and read its stream outputs asynchronously.
+    Execute a process and read its stream outputs synchronously.
+
+    This function uses subprocess.Popen instead of asyncio to avoid
+    issues with asyncio's child watcher when called from non-main
+    threads. On Python 3.12+, asyncio.run() in a non-main thread
+    cannot properly install a SIGCHLD handler, causing race conditions
+    with psutil that result in exit codes being reported as 255.
 
     :param[in] process_args List of process arguments.
     :param[in] environment List of environment variables to be used when executing the process.
@@ -221,19 +226,48 @@ async def run_command(process_args, environment, timeout):
 
     :return Tuple (process return code, lines printed on stderr stream output)
     """
-    proc = await asyncio.create_subprocess_exec(
-        *process_args,
+    proc = subprocess.Popen(
+        process_args,
         env=environment,
-        stdout=PIPE,
-        stderr=PIPE
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
 
     num_lines = [0, 0]
 
+    def read_stream(stream, index):
+        """Read lines from a stream and count them."""
+        try:
+            for line in iter(stream.readline, b''):
+                if line:
+                    num_lines[index] += 1
+                    logger.info(line.decode('utf-8'))
+        except Exception:
+            pass
+
+    # Read stdout and stderr in separate threads
+    stdout_thread = threading.Thread(
+        target=read_stream, args=(proc.stdout, 0), daemon=True)
+    stderr_thread = threading.Thread(
+        target=read_stream, args=(proc.stderr, 1), daemon=True)
+    stdout_thread.start()
+    stderr_thread.start()
+
+    # Wait for the process to finish or timeout
+    process_timed_out = False
     try:
-        await asyncio.wait_for(read_outputs(proc, num_lines), timeout)
-    except asyncio.TimeoutError:
-        pass
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process_timed_out = True
+
+    # If the process already exited within the timeout, collect its exit
+    # code directly, no need to send signals.
+    if not process_timed_out:
+        stdout_thread.join(timeout=2)
+        stderr_thread.join(timeout=2)
+        proc.stdout.close()
+        proc.stderr.close()
+        return (proc.returncode, num_lines[1])
 
     # There are three kinds of processes:
     # a) Standard processes which consist of a domain participant with a XML configuration file. These
@@ -262,25 +296,40 @@ async def run_command(process_args, environment, timeout):
         # b) Fast DDS CLI in ROS2_EASY_MODE
         pass
 
+    # Wait for the parent process to exit gracefully after its child
+    # has been stopped. Only force-kill if it doesn't exit in time.
     try:
-        psutil_proc = psutil.Process(proc.pid)
-        children = psutil_proc.children(recursive=True)
-        if children:
-            for child in children:
-                if 'fast-discovery-server' in child.name():
-                     # c) Standard process
-                    logger.debug(f'Sending SIGKILL signal to: {child.pid}')
-                    child.send_signal(signal.SIGKILL)
-        else:
-            # a) Standard process
-            logger.debug(f'Sending SIGKILL signal to single process: {proc.pid}')
-            proc.kill()
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        try:
+            psutil_proc = psutil.Process(proc.pid)
+            children = psutil_proc.children(recursive=True)
+            if children:
+                for child in children:
+                    if 'fast-discovery-server' in child.name():
+                         # c) Standard process
+                        logger.debug(f'Sending SIGKILL signal to: {child.pid}')
+                        child.send_signal(signal.SIGKILL)
+            else:
+                # a) Standard process
+                logger.debug(f'Sending SIGKILL signal to single process: {proc.pid}')
+                proc.kill()
 
-    except Exception:
-        # b) Fast DDS CLI in ROS2_EASY_MODE
-        pass
+        except Exception:
+            # b) Fast DDS CLI in ROS2_EASY_MODE
+            pass
 
-    return (await proc.wait(), num_lines[1])
+        proc.wait()
+
+    # Wait for output reader threads to finish
+    stdout_thread.join(timeout=2)
+    stderr_thread.join(timeout=2)
+
+    # Close streams
+    proc.stdout.close()
+    proc.stderr.close()
+
+    return (proc.returncode, num_lines[1])
 
 
 def pass_shm_contrains():
@@ -482,9 +531,9 @@ def execute_validate_thread_test(
                 stop_domain = domain_arg
 
     # Execute
-    logger.info(f'Executing process {process_id} in test {test_id} with '
+    logger.debug(f'Executing process {process_id} in test {test_id} with '
                  f'command {process_args}')
-    process_ret, lines = asyncio.run(run_command(process_args, my_env, kill_time))
+    process_ret, lines = run_command_sync(process_args, my_env, kill_time)
 
     # Do not use communicate, as stderr is needed further in validation
 
@@ -532,7 +581,7 @@ def execute_validate_thread_test(
         process_args.append('-d')
         process_args.append(str(stop_domain))
         logger.debug(f'Killing server in domain [{stop_domain}] with process: {process_args}')
-        _, _ = asyncio.run(run_command(process_args, my_env, kill_time))
+        _, _ = run_command_sync(process_args, my_env, kill_time)
 
     # Update result_list and return
     result_list.append(result)
@@ -973,7 +1022,7 @@ if __name__ == '__main__':
         stop_args = [args.fds]
         stop_args.extend(['discovery', 'stop'])
         logger.info(f'Killing Fast DDS daemon with command: {stop_args}')
-        _, _ = asyncio.run(run_command(stop_args, None, 3))
+        _, _ = run_command_sync(stop_args, None, 3)
     else:
         logger.info('No fastdds tool process to stop')
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Replace async run_command() with synchronous run_command_sync() using subprocess.Popen and threaded stream readers. On Python 3.12+, asyncio.run() called from non-main threads cannot properly install a SIGCHLD handler, causing race conditions where child exit status is reaped before asyncio's child watcher, resulting in exit code 255.

Changes:
- New run_command_sync() using subprocess.Popen instead of asyncio
- Skip signal cleanup for processes that exit within their timeout
- Wait up to 5s for graceful exit after SIGINT before resorting to SIGKILL
- Update all three run_command call sites to use run_command_sync

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.2.x 2.1.x 2.0.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The added tests pass locally.
- [x] Changes are backwards compatible. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
